### PR TITLE
TRAD-96 better streaming semantics

### DIFF
--- a/bxserum/connections/common.go
+++ b/bxserum/connections/common.go
@@ -1,0 +1,22 @@
+package connections
+
+type Streamer[T any] func() (T, error)
+
+func (s Streamer[T]) Channel(size int) chan T {
+	ch := make(chan T, size)
+	s.Into(ch)
+	return ch
+}
+
+func (s Streamer[T]) Into(ch chan T) {
+	go func() {
+		for {
+			v, err := s()
+			if err != nil {
+				close(ch)
+				return
+			}
+			ch <- v
+		}
+	}()
+}

--- a/bxserum/connections/ws.go
+++ b/bxserum/connections/ws.go
@@ -215,7 +215,7 @@ func (w *WS) request(ctx context.Context, request jsonrpc2.Request, lockRequired
 	}
 }
 
-func WSStream[T proto.Message](w *WS, ctx context.Context, streamName string, streamParams proto.Message, resultInitFn func() T) (func() (T, error), error) {
+func WSStream[T proto.Message](w *WS, ctx context.Context, streamName string, streamParams proto.Message, resultInitFn func() T) (Streamer[T], error) {
 	streamParamsB, err := protojson.Marshal(streamParams)
 	if err != nil {
 		return nil, err

--- a/bxserum/provider/grpc.go
+++ b/bxserum/provider/grpc.go
@@ -49,13 +49,13 @@ func (g *GRPCClient) GetOrderbook(ctx context.Context, market string, limit uint
 }
 
 // GetOrderbookStream subscribes to a stream for changes to the requested market updates (e.g. asks and bids. Set limit to 0 for all bids/ asks).
-func (g *GRPCClient) GetOrderbookStream(ctx context.Context, markets []string, limit uint32, outputChan chan *pb.GetOrderbooksStreamResponse) error {
+func (g *GRPCClient) GetOrderbookStream(ctx context.Context, markets []string, limit uint32) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error) {
 	stream, err := g.apiClient.GetOrderbooksStream(ctx, &pb.GetOrderbooksRequest{Markets: markets, Limit: limit})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return connections.GRPCStream[pb.GetOrderbooksStreamResponse](stream, fmt.Sprint(markets), outputChan)
+	return connections.GRPCStream[pb.GetOrderbooksStreamResponse](stream, fmt.Sprint(markets)), nil
 }
 
 // GetTrades returns the requested market's currently executing trades. Set limit to 0 for all trades.
@@ -64,23 +64,23 @@ func (g *GRPCClient) GetTrades(ctx context.Context, market string, limit uint32)
 }
 
 // GetTradesStream subscribes to a stream for trades as they execute. Set limit to 0 for all trades.
-func (g *GRPCClient) GetTradesStream(ctx context.Context, market string, limit uint32, outputChan chan *pb.GetTradesStreamResponse) error {
+func (g *GRPCClient) GetTradesStream(ctx context.Context, market string, limit uint32) (connections.Streamer[*pb.GetTradesStreamResponse], error) {
 	stream, err := g.apiClient.GetTradesStream(ctx, &pb.GetTradesRequest{Market: market, Limit: limit})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return connections.GRPCStream[pb.GetTradesStreamResponse](stream, market, outputChan)
+	return connections.GRPCStream[pb.GetTradesStreamResponse](stream, market), nil
 }
 
 // GetOrderStatusStream subscribes to a stream that shows updates to the owner's orders
-func (g *GRPCClient) GetOrderStatusStream(ctx context.Context, market, ownerAddress string, outputChan chan *pb.GetOrderStatusStreamResponse) error {
+func (g *GRPCClient) GetOrderStatusStream(ctx context.Context, market, ownerAddress string) (connections.Streamer[*pb.GetOrderStatusStreamResponse], error) {
 	stream, err := g.apiClient.GetOrderStatusStream(ctx, &pb.GetOrderStatusStreamRequest{Market: market, OwnerAddress: ownerAddress})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return connections.GRPCStream[pb.GetOrderStatusStreamResponse](stream, market, outputChan)
+	return connections.GRPCStream[pb.GetOrderStatusStreamResponse](stream, market), nil
 }
 
 // GetTickers returns the requested market tickets. Set market to "" for all markets.

--- a/bxserum/provider/grpc.go
+++ b/bxserum/provider/grpc.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-
 	"github.com/bloXroute-Labs/serum-client-go/bxserum/connections"
 	"github.com/bloXroute-Labs/serum-client-go/bxserum/transaction"
 	pb "github.com/bloXroute-Labs/serum-client-go/proto"
@@ -48,39 +47,9 @@ func (g *GRPCClient) GetOrderbook(ctx context.Context, market string, limit uint
 	return g.apiClient.GetOrderbook(ctx, &pb.GetOrderbookRequest{Market: market, Limit: limit})
 }
 
-// GetOrderbookStream subscribes to a stream for changes to the requested market updates (e.g. asks and bids. Set limit to 0 for all bids/ asks).
-func (g *GRPCClient) GetOrderbookStream(ctx context.Context, markets []string, limit uint32) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error) {
-	stream, err := g.apiClient.GetOrderbooksStream(ctx, &pb.GetOrderbooksRequest{Markets: markets, Limit: limit})
-	if err != nil {
-		return nil, err
-	}
-
-	return connections.GRPCStream[pb.GetOrderbooksStreamResponse](stream, fmt.Sprint(markets)), nil
-}
-
 // GetTrades returns the requested market's currently executing trades. Set limit to 0 for all trades.
 func (g *GRPCClient) GetTrades(ctx context.Context, market string, limit uint32) (*pb.GetTradesResponse, error) {
 	return g.apiClient.GetTrades(ctx, &pb.GetTradesRequest{Market: market, Limit: limit})
-}
-
-// GetTradesStream subscribes to a stream for trades as they execute. Set limit to 0 for all trades.
-func (g *GRPCClient) GetTradesStream(ctx context.Context, market string, limit uint32) (connections.Streamer[*pb.GetTradesStreamResponse], error) {
-	stream, err := g.apiClient.GetTradesStream(ctx, &pb.GetTradesRequest{Market: market, Limit: limit})
-	if err != nil {
-		return nil, err
-	}
-
-	return connections.GRPCStream[pb.GetTradesStreamResponse](stream, market), nil
-}
-
-// GetOrderStatusStream subscribes to a stream that shows updates to the owner's orders
-func (g *GRPCClient) GetOrderStatusStream(ctx context.Context, market, ownerAddress string) (connections.Streamer[*pb.GetOrderStatusStreamResponse], error) {
-	stream, err := g.apiClient.GetOrderStatusStream(ctx, &pb.GetOrderStatusStreamRequest{Market: market, OwnerAddress: ownerAddress})
-	if err != nil {
-		return nil, err
-	}
-
-	return connections.GRPCStream[pb.GetOrderStatusStreamResponse](stream, market), nil
 }
 
 // GetTickers returns the requested market tickets. Set market to "" for all markets.
@@ -319,4 +288,34 @@ func (g *GRPCClient) SubmitReplaceOrder(ctx context.Context, orderID, owner, pay
 	}
 
 	return g.signAndSubmit(ctx, order.Transaction, opts.SkipPreFlight)
+}
+
+// GetOrderbookStream subscribes to a stream for changes to the requested market updates (e.g. asks and bids. Set limit to 0 for all bids/ asks).
+func (g *GRPCClient) GetOrderbookStream(ctx context.Context, markets []string, limit uint32) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error) {
+	stream, err := g.apiClient.GetOrderbooksStream(ctx, &pb.GetOrderbooksRequest{Markets: markets, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+
+	return connections.GRPCStream[pb.GetOrderbooksStreamResponse](stream, fmt.Sprint(markets)), nil
+}
+
+// GetTradesStream subscribes to a stream for trades as they execute. Set limit to 0 for all trades.
+func (g *GRPCClient) GetTradesStream(ctx context.Context, market string, limit uint32) (connections.Streamer[*pb.GetTradesStreamResponse], error) {
+	stream, err := g.apiClient.GetTradesStream(ctx, &pb.GetTradesRequest{Market: market, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+
+	return connections.GRPCStream[pb.GetTradesStreamResponse](stream, market), nil
+}
+
+// GetOrderStatusStream subscribes to a stream that shows updates to the owner's orders
+func (g *GRPCClient) GetOrderStatusStream(ctx context.Context, market, ownerAddress string) (connections.Streamer[*pb.GetOrderStatusStreamResponse], error) {
+	stream, err := g.apiClient.GetOrderStatusStream(ctx, &pb.GetOrderStatusStreamRequest{Market: market, OwnerAddress: ownerAddress})
+	if err != nil {
+		return nil, err
+	}
+
+	return connections.GRPCStream[pb.GetOrderStatusStreamResponse](stream, market), nil
 }

--- a/bxserum/provider/ws.go
+++ b/bxserum/provider/ws.go
@@ -66,16 +66,7 @@ func (w *WSClient) GetOrderbooksStream(ctx context.Context, markets []string, li
 		return err
 	}
 
-	go func() {
-		for {
-			result, err := generator()
-			if err != nil {
-				close(orderbookChan)
-				return
-			}
-			orderbookChan <- result
-		}
-	}()
+	generator.Into(orderbookChan)
 	return nil
 }
 
@@ -102,17 +93,7 @@ func (w *WSClient) GetTradesStream(ctx context.Context, market string, limit uin
 		return err
 	}
 
-	go func() {
-		for {
-			result, err := generator()
-			if err != nil {
-				close(tradesChan)
-				return
-			}
-			tradesChan <- result
-		}
-	}()
-
+	generator.Into(tradesChan)
 	return nil
 }
 
@@ -129,17 +110,7 @@ func (w *WSClient) GetOrderStatusStream(ctx context.Context, market, ownerAddres
 		return err
 	}
 
-	go func() {
-		for {
-			result, err := generator()
-			if err != nil {
-				close(statusUpdateChan)
-				return
-			}
-			statusUpdateChan <- result
-		}
-	}()
-
+	generator.Into(statusUpdateChan)
 	return nil
 }
 

--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -147,7 +147,6 @@ func callTickersGRPC(g *provider.GRPCClient) {
 func callOrderbookGRPCStream(g *provider.GRPCClient) {
 	fmt.Println("starting orderbook stream")
 
-	orderbookChan := make(chan *pb.GetOrderbooksStreamResponse)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -158,9 +157,9 @@ func callOrderbookGRPCStream(g *provider.GRPCClient) {
 		return
 	}
 
-	stream.Into(orderbookChan)
+	orderbookCh := stream.Channel(0)
 	for i := 1; i <= 5; i++ {
-		data, ok := <-orderbookChan
+		data, ok := <-orderbookCh
 		if !ok {
 			// channel closed
 			return


### PR DESCRIPTION
Instead of forcing the channel interface, expose utility methods `Channel` and `Into` for quick wrapping of the invoked receiver into a channel.