### PR TITLE
TRAD-590 Make Drift use consistently the term "contract"

### DIFF
--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -1140,9 +1140,9 @@ func callDriftOrderbookGRPCStream(g *provider.GRPCClient) bool {
 
 	// Stream response
 	stream, err := g.GetPerpOrderbooksStream(ctx, &pb.GetPerpOrderbooksRequest{
-		Markets: []string{"SOL-PERP"},
-		Limit:   0,
-		Project: pb.Project_P_DRIFT,
+		Contracts: []common.PerpContract{common.PerpContract_SOL_PERP},
+		Limit:     0,
+		Project:   pb.Project_P_DRIFT,
 	})
 	if err != nil {
 		log.Errorf("error with GetPerpOrderbooksStream stream request: %v", err)
@@ -1163,9 +1163,9 @@ func callDriftOrderbookGRPCStream(g *provider.GRPCClient) bool {
 
 func callDriftOrderbookGRPC(g *provider.GRPCClient) bool {
 	orderbook, err := g.GetPerpOrderbook(context.Background(), &pb.GetPerpOrderbookRequest{
-		Market:  "SOL-PERP",
-		Limit:   0,
-		Project: pb.Project_P_DRIFT,
+		Contract: common.PerpContract_SOL_PERP,
+		Limit:    0,
+		Project:  pb.Project_P_DRIFT,
 	})
 	if err != nil {
 		log.Errorf("error with GetPerpOrderbook request for SOL-PERP: %v", err)

--- a/examples/httpclient/main.go
+++ b/examples/httpclient/main.go
@@ -828,9 +828,9 @@ func callDriftOrderbookHTTP() bool {
 	defer cancel()
 
 	orderbook, err := h.GetPerpOrderbook(ctx, &pb.GetPerpOrderbookRequest{
-		Market:  "SOL-PERP",
-		Limit:   0,
-		Project: pb.Project_P_DRIFT,
+		Contract: common.PerpContract_SOL_PERP,
+		Limit:    0,
+		Project:  pb.Project_P_DRIFT,
 	})
 	if err != nil {
 		log.Errorf("error with GetPerpOrderbook request for SOL-PERP: %v", err)

--- a/examples/wsclient/main.go
+++ b/examples/wsclient/main.go
@@ -1024,9 +1024,9 @@ func callDriftOrderbookWS(w *provider.WSClient) bool {
 	log.Info("fetching drift orderbooks...")
 
 	orderbook, err := w.GetPerpOrderbook(context.Background(), &pb.GetPerpOrderbookRequest{
-		Market:  "SOL-PERP",
-		Limit:   0,
-		Project: pb.Project_P_DRIFT,
+		Contract: common.PerpContract_SOL_PERP,
+		Limit:    0,
+		Project:  pb.Project_P_DRIFT,
 	})
 	if err != nil {
 		log.Errorf("error with GetPerpOrderbook request for SOL-PERP: %v", err)
@@ -1046,9 +1046,9 @@ func callDriftOrderbookWSStream(w *provider.WSClient) bool {
 	defer cancel()
 
 	stream, err := w.GetPerpOrderbooksStream(ctx, &pb.GetPerpOrderbooksRequest{
-		Markets: []string{"SOL-PERP"},
-		Limit:   0,
-		Project: pb.Project_P_DRIFT,
+		Contracts: []common.PerpContract{common.PerpContract_SOL_PERP},
+		Limit:     0,
+		Project:   pb.Project_P_DRIFT,
 	})
 	if err != nil {
 		log.Errorf("error with GetPerpOrderbooksStream request for SOL-PERP: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bloXroute-Labs/solana-trader-client-go
 go 1.18
 
 require (
-	github.com/bloXroute-Labs/solana-trader-proto v1.3.1-0.20230313173554-dd297d027d00
+	github.com/bloXroute-Labs/solana-trader-proto v1.5.1-0.20230323193256-807ad8b36246
 	github.com/gagliardetto/binary v0.7.7
 	github.com/gagliardetto/solana-go v1.8.2
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/bloXroute-Labs/solana-trader-proto v1.3.1-0.20230310191532-ac9253042b
 github.com/bloXroute-Labs/solana-trader-proto v1.3.1-0.20230310191532-ac9253042bab/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/bloXroute-Labs/solana-trader-proto v1.3.1-0.20230313173554-dd297d027d00 h1:a60n1eSOdJHJXTrMfy882ZlP+ORsXW7GD2AuF+pcDMA=
 github.com/bloXroute-Labs/solana-trader-proto v1.3.1-0.20230313173554-dd297d027d00/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
+github.com/bloXroute-Labs/solana-trader-proto v1.5.1-0.20230323193256-807ad8b36246 h1:m3onBkM2kUv2StYcmoro+s3KeoSpKtQxn4vvB03wumE=
+github.com/bloXroute-Labs/solana-trader-proto v1.5.1-0.20230323193256-807ad8b36246/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/provider/http.go
+++ b/provider/http.go
@@ -838,7 +838,7 @@ func (h *HTTPClient) GetRecentBlockHash(ctx context.Context) (*pb.GetRecentBlock
 
 // GetPerpOrderbook returns the current state of perpetual contract orderbook.
 func (h *HTTPClient) GetPerpOrderbook(ctx context.Context, request *pb.GetPerpOrderbookRequest) (*pb.GetPerpOrderbookResponse, error) {
-	url := fmt.Sprintf("%s/api/v1/trade/perp/orderbook/%s?limit=%d&project=%v", h.baseURL, request.Contract, request.Limit, request.Project)
+	url := fmt.Sprintf("%s/api/v1/market/perp/orderbook/%s?limit=%d&project=%v", h.baseURL, request.Contract, request.Limit, request.Project)
 	orderbook := new(pb.GetPerpOrderbookResponse)
 	if err := connections.HTTPGetWithClient[*pb.GetPerpOrderbookResponse](ctx, url, h.httpClient, orderbook, h.authHeader); err != nil {
 		return nil, err

--- a/provider/http.go
+++ b/provider/http.go
@@ -838,7 +838,7 @@ func (h *HTTPClient) GetRecentBlockHash(ctx context.Context) (*pb.GetRecentBlock
 
 // GetPerpOrderbook returns the current state of perpetual contract orderbook.
 func (h *HTTPClient) GetPerpOrderbook(ctx context.Context, request *pb.GetPerpOrderbookRequest) (*pb.GetPerpOrderbookResponse, error) {
-	url := fmt.Sprintf("%s/api/v1/trade/perp/orderbook/%s?limit=%d&project=%v", h.baseURL, request.Market, request.Limit, request.Project)
+	url := fmt.Sprintf("%s/api/v1/trade/perp/orderbook/%s?limit=%d&project=%v", h.baseURL, request.Contract, request.Limit, request.Project)
 	orderbook := new(pb.GetPerpOrderbookResponse)
 	if err := connections.HTTPGetWithClient[*pb.GetPerpOrderbookResponse](ctx, url, h.httpClient, orderbook, h.authHeader); err != nil {
 		return nil, err


### PR DESCRIPTION
TRAD-590 Make Drift use consistently the term "contract" instead of "market"