### PR TITLE
add support for nil param rpc methods

### DIFF
--- a/connections/jsonrpc.go
+++ b/connections/jsonrpc.go
@@ -28,7 +28,13 @@ func (s SubscribeParams) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	params := []json.RawMessage{nameB, s.StreamOpts}
+	var params []json.RawMessage
+	if s.StreamOpts == nil {
+		params = []json.RawMessage{nameB}
+	} else {
+		params = []json.RawMessage{nameB, s.StreamOpts}
+	}
+
 	return json.Marshal(params)
 }
 

--- a/connections/ws.go
+++ b/connections/ws.go
@@ -264,7 +264,7 @@ func wsStream[T any](w *WS, ctx context.Context, streamName string, streamParams
 		StreamOpts: streamParams,
 	}
 
-	paramsB, err := json.Marshal(params)
+	paramsB, err := params.MarshalJSON()
 	if err != nil {
 		return nil, err
 	}

--- a/connections/ws.go
+++ b/connections/ws.go
@@ -225,10 +225,20 @@ func (w *WS) request(ctx context.Context, request jsonrpc2.Request, lockRequired
 }
 
 func WSStreamAny[T any](w *WS, ctx context.Context, streamName string, streamParams interface{}) (Streamer[T], error) {
-	streamParamsB, err := json.Marshal(streamParams)
-	if err != nil {
-		return nil, err
+	var (
+		err           error
+		streamParamsB []byte
+	)
+
+	if streamParams == nil {
+		streamParamsB = nil
+	} else {
+		streamParamsB, err = json.Marshal(streamParams)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	return wsStream(w, ctx, streamName, streamParamsB, func(b []byte) (T, error) {
 		var v T
 		err := json.Unmarshal(b, &v)
@@ -249,14 +259,26 @@ func WSStreamProto[T proto.Message](w *WS, ctx context.Context, streamName strin
 }
 
 func wsStream[T any](w *WS, ctx context.Context, streamName string, streamParams json.RawMessage, unmarshal func(b []byte) (T, error)) (Streamer[T], error) {
-	params := SubscribeParams{
-		StreamName: streamName,
-		StreamOpts: streamParams,
+	var (
+		err     error
+		paramsB []byte
+	)
+	if streamParams == nil {
+		paramsB, err = json.Marshal([]string{streamName})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		params := SubscribeParams{
+			StreamName: streamName,
+			StreamOpts: streamParams,
+		}
+		paramsB, err = json.Marshal(params)
+		if err != nil {
+			return nil, err
+		}
 	}
-	paramsB, err := json.Marshal(params)
-	if err != nil {
-		return nil, err
-	}
+
 	rawParams := json.RawMessage(paramsB)
 	rpcRequest := jsonrpc2.Request{
 		Method: w.SubscribeMethodName,

--- a/connections/ws.go
+++ b/connections/ws.go
@@ -259,24 +259,14 @@ func WSStreamProto[T proto.Message](w *WS, ctx context.Context, streamName strin
 }
 
 func wsStream[T any](w *WS, ctx context.Context, streamName string, streamParams json.RawMessage, unmarshal func(b []byte) (T, error)) (Streamer[T], error) {
-	var (
-		err     error
-		paramsB []byte
-	)
-	if streamParams == nil {
-		paramsB, err = json.Marshal([]string{streamName})
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		params := SubscribeParams{
-			StreamName: streamName,
-			StreamOpts: streamParams,
-		}
-		paramsB, err = json.Marshal(params)
-		if err != nil {
-			return nil, err
-		}
+	params := SubscribeParams{
+		StreamName: streamName,
+		StreamOpts: streamParams,
+	}
+
+	paramsB, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
 	}
 
 	rawParams := json.RawMessage(paramsB)

--- a/connections/ws.go
+++ b/connections/ws.go
@@ -264,7 +264,7 @@ func wsStream[T any](w *WS, ctx context.Context, streamName string, streamParams
 		StreamOpts: streamParams,
 	}
 
-	paramsB, err := params.MarshalJSON()
+	paramsB, err := json.Marshal(params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For format of json rpc subscribe calls as such: 

> {“jsonrpc”:“2.0", “id”:1, “method”: “eth_subscribe”, “params”: [“newPendingTransactions”]}
> {“jsonrpc”:“2.0”,“id”: 1, “method”: “eth_subscribe”, “params”: [“newHeads”]}

where we just need an array of ["newPendingTransaction"] and not ["newPendingTransactions": nil]