### PR TITLE
Setup for Go SDK to support retrieving new Raydium cpmm pools

### DIFF
--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -83,6 +83,7 @@ func run() bool {
 		failed = failed || logCall("callTradesGRPCStream", func() bool { return callTradesGRPCStream(g) })
 		failed = failed || logCall("callSwapsGRPCStream", func() bool { return callSwapsGRPCStream(g) })
 		failed = failed || logCall("callGetNewRaydiumPoolsStream", func() bool { return callGetNewRaydiumPoolsStream(g) })
+		failed = failed || logCall("callGetNewRaydiumPoolsStreamWithCPMM", func() bool { return callGetNewRaydiumPoolsStreamWithCPMM(g) })
 	}
 
 	failed = failed || logCall("callUnsettledGRPC", func() bool { return callUnsettledGRPC(g) })
@@ -1637,14 +1638,40 @@ func callSwapsGRPCStream(g *provider.GRPCClient) bool {
 }
 
 func callGetNewRaydiumPoolsStream(g *provider.GRPCClient) bool {
-	log.Info("starting get new raydium pools stream")
+	log.Info("starting get new raydium pools stream without cpmm")
 
 	ch := make(chan *pb.GetNewRaydiumPoolsResponse)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Stream response
-	stream, err := g.GetNewRaydiumPoolsStream(ctx)
+	stream, err := g.GetNewRaydiumPoolsStream(ctx, false)
+	if err != nil {
+		log.Errorf("error with GetNewRaydiumPools stream request: %v", err)
+		return true
+	}
+	stream.Into(ch)
+	for i := 1; i <= 1; i++ {
+		_, ok := <-ch
+		if !ok {
+			// channel closed
+			return true
+		}
+
+		log.Infof("response %v received", i)
+	}
+	return false
+}
+
+func callGetNewRaydiumPoolsStreamWithCPMM(g *provider.GRPCClient) bool {
+	log.Info("starting get new raydium pools stream with cpmm")
+
+	ch := make(chan *pb.GetNewRaydiumPoolsResponse)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Stream response
+	stream, err := g.GetNewRaydiumPoolsStream(ctx, true)
 	if err != nil {
 		log.Errorf("error with GetNewRaydiumPools stream request: %v", err)
 		return true

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240521170541-1e836cb94d13
+	github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b
 	github.com/gagliardetto/binary v0.7.7
 	github.com/gagliardetto/solana-go v1.8.4
 	github.com/gorilla/websocket v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b
+	github.com/bloXroute-Labs/solana-trader-proto v1.9.1
 	github.com/gagliardetto/binary v0.7.7
 	github.com/gagliardetto/solana-go v1.8.4
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b h1:Lm+OPdCvkSaoW9v5D2K+pX9jTHFiO2TmSColShCCPgQ=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.1 h1:cQULoUVWJ10Zg9AI7Of5hNQlnj2W4ccusfCAfVnz3kk=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.1/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240521170541-1e836cb94d13 h1:8J6d5KSEP1lFZ9rgGDQrw6b+LwWmN48OeMBYMQcDo20=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240521170541-1e836cb94d13/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b h1:Lm+OPdCvkSaoW9v5D2K+pX9jTHFiO2TmSColShCCPgQ=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.1-0.20240611182242-cc26d964387b/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/provider/common.go
+++ b/provider/common.go
@@ -15,7 +15,7 @@ import (
 const (
 	mainnetNY = "ny.solana.dex.blxrbdn.com"
 	mainnetUK = "uk.solana.dex.blxrbdn.com"
-	testnet   = "serum-nlb-5a2c3912804344a3.elb.us-east-1.amazonaws.com"
+	testnet   = "solana.dex.bxrtest.com"
 	devnet    = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
 )
 
@@ -27,9 +27,9 @@ var (
 	MainnetNYGRPC = grpcEndpoint(mainnetNY, true)
 	MainnetUKGRPC = grpcEndpoint(mainnetUK, true)
 
-	TestnetHTTP = httpEndpoint(testnet, false)
-	TestnetWS   = wsEndpoint(testnet, false)
-	TestnetGRPC = grpcEndpoint(testnet, false)
+	TestnetHTTP = httpEndpoint(testnet, true)
+	TestnetWS   = wsEndpoint(testnet, true)
+	TestnetGRPC = grpcEndpoint(testnet, true)
 
 	DevnetHTTP = httpEndpoint(devnet, false)
 	DevnetWS   = wsEndpoint(devnet, false)

--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -36,6 +36,7 @@ func NewGRPCClient() (*GRPCClient, error) {
 // NewGRPCTestnet connects to Testnet Trader API
 func NewGRPCTestnet() (*GRPCClient, error) {
 	opts := DefaultRPCOpts(TestnetGRPC)
+	opts.UseTLS = true
 	return NewGRPCClientWithOpts(opts)
 }
 

--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -840,9 +840,18 @@ func (g *GRPCClient) GetSwapsStream(
 
 // GetNewRaydiumPoolsStream subscribes to a stream for getting recent swaps on projects & markets of interest.
 func (g *GRPCClient) GetNewRaydiumPoolsStream(
-	ctx context.Context,
+	ctx context.Context) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
+	return g.GetNewRaydiumPoolsStreamV2(ctx, false)
+}
+
+// GetNewRaydiumPoolsStreamV2 subscribes to a stream for getting recent swaps on projects & markets of interest with
+// option to include Raydium cpmm amm.
+func (g *GRPCClient) GetNewRaydiumPoolsStreamV2(
+	ctx context.Context, includeCPMM bool,
 ) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
-	stream, err := g.apiClient.GetNewRaydiumPoolsStream(ctx, &pb.GetNewRaydiumPoolsRequest{})
+	stream, err := g.apiClient.GetNewRaydiumPoolsStream(ctx, &pb.GetNewRaydiumPoolsRequest{
+		IncludeCPMM: &includeCPMM,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -838,15 +838,9 @@ func (g *GRPCClient) GetSwapsStream(
 	return connections.GRPCStream[pb.GetSwapsStreamResponse](stream, ""), nil
 }
 
-// GetNewRaydiumPoolsStream subscribes to a stream for getting recent swaps on projects & markets of interest.
-func (g *GRPCClient) GetNewRaydiumPoolsStream(
-	ctx context.Context) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
-	return g.GetNewRaydiumPoolsStreamV2(ctx, false)
-}
-
-// GetNewRaydiumPoolsStreamV2 subscribes to a stream for getting recent swaps on projects & markets of interest with
+// GetNewRaydiumPoolsStream subscribes to a stream for getting recent swaps on projects & markets of interest with
 // option to include Raydium cpmm amm.
-func (g *GRPCClient) GetNewRaydiumPoolsStreamV2(
+func (g *GRPCClient) GetNewRaydiumPoolsStream(
 	ctx context.Context, includeCPMM bool,
 ) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
 	stream, err := g.apiClient.GetNewRaydiumPoolsStream(ctx, &pb.GetNewRaydiumPoolsRequest{

--- a/provider/http.go
+++ b/provider/http.go
@@ -32,6 +32,7 @@ func NewHTTPClient() *HTTPClient {
 // NewHTTPTestnet connects to Testnet Trader API
 func NewHTTPTestnet() *HTTPClient {
 	opts := DefaultRPCOpts(TestnetHTTP)
+	opts.UseTLS = true
 	return NewHTTPClientWithOpts(nil, opts)
 }
 

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -985,10 +985,20 @@ func (w *WSClient) GetTradesStream(ctx context.Context, market string, limit uin
 
 // GetNewRaydiumPoolsStream subscribes to a stream for new Raydium Pools when they are created.
 func (w *WSClient) GetNewRaydiumPoolsStream(ctx context.Context) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
-	return connections.WSStreamProto(w.conn, ctx, "GetNewRaydiumPoolsStream", &pb.GetNewRaydiumPoolsRequest{}, func() *pb.GetNewRaydiumPoolsResponse {
-		var v pb.GetNewRaydiumPoolsResponse
-		return &v
-	})
+	return w.GetNewRaydiumPoolsStreamV2(ctx, false)
+}
+
+// GetNewRaydiumPoolsStreamV2 subscribes to a stream for new Raydium Pools when they are created with
+// option to include Raydium cpmm amm.
+func (w *WSClient) GetNewRaydiumPoolsStreamV2(ctx context.Context, includeCPMM bool) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
+	return connections.WSStreamProto(w.conn, ctx, "GetNewRaydiumPoolsStream",
+		&pb.GetNewRaydiumPoolsRequest{
+			IncludeCPMM: &includeCPMM,
+		},
+		func() *pb.GetNewRaydiumPoolsResponse {
+			var v pb.GetNewRaydiumPoolsResponse
+			return &v
+		})
 }
 
 // GetOrderStatusStream subscribes to a stream that shows updates to the owner's orders

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -983,14 +983,9 @@ func (w *WSClient) GetTradesStream(ctx context.Context, market string, limit uin
 	})
 }
 
-// GetNewRaydiumPoolsStream subscribes to a stream for new Raydium Pools when they are created.
-func (w *WSClient) GetNewRaydiumPoolsStream(ctx context.Context) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
-	return w.GetNewRaydiumPoolsStreamV2(ctx, false)
-}
-
-// GetNewRaydiumPoolsStreamV2 subscribes to a stream for new Raydium Pools when they are created with
+// GetNewRaydiumPoolsStream subscribes to a stream for new Raydium Pools when they are created with
 // option to include Raydium cpmm amm.
-func (w *WSClient) GetNewRaydiumPoolsStreamV2(ctx context.Context, includeCPMM bool) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
+func (w *WSClient) GetNewRaydiumPoolsStream(ctx context.Context, includeCPMM bool) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error) {
 	return connections.WSStreamProto(w.conn, ctx, "GetNewRaydiumPoolsStream",
 		&pb.GetNewRaydiumPoolsRequest{
 			IncludeCPMM: &includeCPMM,

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -30,6 +30,7 @@ func NewWSClient() (*WSClient, error) {
 // NewWSClientTestnet connects to Testnet Trader API
 func NewWSClientTestnet() (*WSClient, error) {
 	opts := DefaultRPCOpts(TestnetWS)
+	opts.UseTLS = true
 	return NewWSClientWithOpts(opts)
 }
 


### PR DESCRIPTION
Setup Notes:
 1. To test locally, you will need to pull the solanal-trader-proto branch TRAD-1031/support-raydium-new-cpmm-pool.
 2. Then use a replace command in the go.mod to point to the local proto version.

Details:
1. Adds in GetNewRaydiumPoolsStreamV2 for the GRPCClient and WSClient which adds additional parameter includeCPMM.
2. Refactors original GetNewRaydiumPoolsStream to call V2 version with includeCPMM set to false.
