### PR TITLE
Support the new PumpFun AMM pools stream

### DIFF
--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"math/rand"
 	"os"
 	"sort"
 	"time"
+
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
@@ -354,7 +355,10 @@ var ExampleEndpoints = map[string]struct {
 		run:         callGetpumpFunNewTokenGRPCStreamWrap,
 		description: "get pump fun new token stream",
 	},
-
+	"getPumpFunNewAmmPoolStream": {
+		run:         callGetPumpFunNewAmmPoolGRPCStream,
+		description: "get new amm pools on pump swap",
+	},
 	"getBundleTipStream": {
 		run:         callGetBundleTipGRPCStream,
 		description: "get bundle tip stream",
@@ -2236,6 +2240,35 @@ func callGetPumpFunNewTokensGRPCStream(g provider.GRPCClientTraderAPI) (string, 
 		mint = v.Mint
 	}
 	return mint, false
+}
+
+func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
+	gg, err := provider.NewGRPCClientPumpNY()
+	if err != nil {
+		log.Errorf("failed to create pump provider: %v", err)
+		return true
+	}
+
+	log.Info("starting GetPumpFunNewAmmPool stream")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := gg.GetPumpFunNewAmmPoolStream(ctx, &pb.GetPumpFunNewAmmPoolStreamRequest{})
+	if err != nil {
+		log.Errorf("error with GetPumpFunNewAmmPool stream request: %v", err)
+		return true
+	}
+
+	ch := stream.Channel(0)
+	for i := 1; i <= 1; i++ {
+		v, ok := <-ch
+		if !ok {
+			return true
+		}
+		log.Infof("response %v received", v)
+	}
+	return false
 }
 
 func callGetPumpFunSwapsGRPCStream(g provider.GRPCClientTraderAPI, mint string) bool {

--- a/examples/wsclient/main.go
+++ b/examples/wsclient/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
-	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"math/rand"
 	"os"
 	"sort"
 	"time"
+
+	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
+	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
@@ -357,7 +358,10 @@ var ExampleEndpoints = map[string]struct {
 		run:         callGetPumpFunNewTokensWSStreamWrap,
 		description: "get pump fun new token stream",
 	},
-
+	"getPumpFunNewAmmPoolStream": {
+		run:         callGetPumpFunNewAmmPoolWSStream,
+		description: "get new amm pools on pump swap",
+	},
 	"getBundleTipStream": {
 		run:         callGetBundleTipWSStream,
 		description: "get bundle tip stream",
@@ -2269,6 +2273,35 @@ func callGetPumpFunNewTokensWSStream(w provider.WSClientTraderAPI) (string, bool
 		mint = v.Mint
 	}
 	return mint, false
+}
+
+func callGetPumpFunNewAmmPoolWSStream(w provider.WSClientTraderAPI) bool {
+	log.Info("starting GetPumpFunNewAmmPool stream")
+
+	wp, err := provider.NewWSClientPumpNY()
+	if err != nil {
+		log.Errorf("failed to create pump fun provider: %v", err)
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := wp.GetPumpFunNewAmmPoolStream(ctx, &pb.GetPumpFunNewAmmPoolStreamRequest{})
+	if err != nil {
+		log.Errorf("error with GetPumpFunNewAmmPool stream request: %v", err)
+		return true
+	}
+
+	ch := stream.Channel(0)
+	for i := 1; i <= 1; i++ {
+		v, ok := <-ch
+		if !ok {
+			return true
+		}
+		log.Infof("response %v received", v)
+	}
+	return false
 }
 
 func callGetPumpFunSwapsWSStream(w provider.WSClientTraderAPI, mint string) bool {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.4
 
 require (
-	github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250318014321-3bcfd1425d22
+	github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250326175608-b60a6a33d927
 	github.com/gagliardetto/binary v0.8.0
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -11,12 +11,10 @@ github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz
 github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250226202856-64892700d9ad h1:6ZZbVoTze6tUemykaXw5pe5wICruI4j+OOY49JWBEm0=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250226202856-64892700d9ad/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250317201339-613c4b196760 h1:EfnOJOAasD+qZY3aF5Zs9E2yICncqoa0RqKsxBjUpgg=
-github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250317201339-613c4b196760/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250318014321-3bcfd1425d22 h1:8sBhUMLbdF5zVtxmUnjHNOT32XucNxPQArhyDw8V2XM=
 github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250318014321-3bcfd1425d22/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250326175608-b60a6a33d927 h1:JxVsmqLmG+XHFv6keyqeoqAWCf3kTK6En2bjkY573nw=
+github.com/bloXroute-Labs/solana-trader-proto v1.9.3-0.20250326175608-b60a6a33d927/go.mod h1:OPAXgJCllC8aCvjRO1uOvpd1eHP0x5Rfr61oQAZEX8Y=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -810,6 +810,16 @@ func (g *GRPCClient) GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpF
 	return connections.GRPCStream[pb.GetPumpFunSwapsStreamResponse](stream, ""), nil
 }
 
+// GetPumpFunNewAmmPoolStream subscribes to a stream for new AMM pool events in Pump Swap
+func (g *GRPCClient) GetPumpFunNewAmmPoolStream(ctx context.Context, req *pb.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*pb.GetPumpFunNewAmmPoolStreamResponse], error) {
+	stream, err := g.apiClient.GetPumpFunNewAmmPoolStream(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return connections.GRPCStream[pb.GetPumpFunNewAmmPoolStreamResponse](stream, ""), nil
+}
+
 // GetPumpFunNewTokensStream subscribes to a stream for pumpdotfun's new pool events
 func (g *GRPCClient) GetPumpFunNewTokensStream(ctx context.Context, req *pb.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*pb.GetPumpFunNewTokensStreamResponse], error) {
 	stream, err := g.apiClient.GetPumpFunNewTokensStream(ctx, req)

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -157,6 +157,7 @@ type GRPCClientTraderAPI interface {
 		ctx context.Context, includeCPMM bool,
 	) (connections.Streamer[*pb.GetNewRaydiumPoolsByTransactionResponse], error)
 	GetBlockStream(ctx context.Context) (connections.Streamer[*pb.GetBlockStreamResponse], error)
+	GetPumpFunNewAmmPoolStream(ctx context.Context, req *pb.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*pb.GetPumpFunNewAmmPoolStreamResponse], error)
 	GetPriorityFeeStream(ctx context.Context, project pb.Project, percentile *float64) (connections.Streamer[*pb.GetPriorityFeeResponse], error)
 	GetPriorityFeeByProgramStream(ctx context.Context, programs []string) (connections.Streamer[*pb.GetPriorityFeeByProgramResponse], error)
 	GetBundleTipStream(ctx context.Context) (connections.Streamer[*pb.GetBundleTipResponse], error)

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -1155,6 +1155,14 @@ func (w *WSClient) GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpFun
 	})
 }
 
+// GetPumpFunNewAmmPoolStream subscribes to a stream for new AMM pool events
+func (w *WSClient) GetPumpFunNewAmmPoolStream(ctx context.Context, req *pb.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*pb.GetPumpFunNewAmmPoolStreamResponse], error) {
+	return connections.WSStreamProto(w.conn, ctx, "GetPumpFunNewAmmPoolStream", req, func() *pb.GetPumpFunNewAmmPoolStreamResponse {
+		var v pb.GetPumpFunNewAmmPoolStreamResponse
+		return &v
+	})
+}
+
 // GetPumpFunNewTokensStream subscribes to a stream for pumpdotfun's new pool events
 func (w *WSClient) GetPumpFunNewTokensStream(ctx context.Context, req *pb.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*pb.GetPumpFunNewTokensStreamResponse], error) {
 	return connections.WSStreamProto(w.conn, ctx, "GetPumpFunNewTokensStream", req, func() *pb.GetPumpFunNewTokensStreamResponse {

--- a/provider/ws_interfaces.go
+++ b/provider/ws_interfaces.go
@@ -147,6 +147,7 @@ type WSClientTraderAPI interface {
 		includeFailed bool,
 	) (connections.Streamer[*api.GetSwapsStreamResponse], error)
 	GetBlockStream(ctx context.Context) (connections.Streamer[*api.GetBlockStreamResponse], error)
+	GetPumpFunNewAmmPoolStream(ctx context.Context, req *api.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*api.GetPumpFunNewAmmPoolStreamResponse], error)
 	GetPriorityFeeStream(ctx context.Context, project api.Project, percentile *float64) (connections.Streamer[*api.GetPriorityFeeResponse], error)
 	GetPriorityFeeByProgramStream(ctx context.Context, programs []string) (connections.Streamer[*api.GetPriorityFeeByProgramResponse], error)
 	GetBundleTipStream(ctx context.Context) (connections.Streamer[*api.GetBundleTipResponse], error)


### PR DESCRIPTION
## Added gRPC and WebSocket support for `GetPumpFunNewAmmPoolStream` endpoint

- Implemented gRPC and WebSocket support for the new `GetPumpFunNewAmmPoolStream` endpoint.
- Included examples for both protocols in `/examples/ws/main.go` and `/examples/grpc/main.go`.
- Tested both examples, and verified they work as expected.
- Ran `make test`, and all tests passed successfully.
