### PR TITLE
Added missing endpoints.

### DIFF
--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -12,6 +12,32 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+// Get the server time
+func (g *GRPCClient) GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error) {
+	return g.apiClient.GetServerTime(ctx, request)
+}
+
+// Submit a transaction to Paladin validator
+func (g *GRPCClient) PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error) {
+	return g.apiClient.PostSubmitPaladinV2(ctx, request)
+}
+
+// Post a pump fun swap in SOL
+func (g *GRPCClient) PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error) {
+	return g.apiClient.PostPumpFunSwapSol(ctx, request)
+}
+
+// Post a Raydium swap for a specific route
+func (g *GRPCClient) PostRaydiumCLMMRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest) (*pb.PostRaydiumRouteSwapResponse, error) {
+	return g.apiClient.PostRaydiumCLMMRouteSwap(ctx, request)
+}
+
+// Post a Raydium swap for CLMM pools
+func (g *GRPCClient) PostRaydiumCLMMSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest) (*pb.PostRaydiumSwapResponse, error) {
+	return g.apiClient.PostRaydiumCLMMSwap(ctx, request)
+}
+
+// Get the most recently cached block hash
 func (g *GRPCClient) RecentBlockHash(ctx context.Context) (*pb.GetRecentBlockHashResponse, error) {
 	return g.recentBlockHashStore.get(ctx)
 }

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+
 	package_info "github.com/bloXroute-Labs/solana-trader-client-go"
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
@@ -15,10 +16,11 @@ import (
 )
 
 type GRPCClientTraderAPISubmitOnly interface {
-	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage,
-		skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
+	PostSubmit(ctx context.Context, tx *pb.TransactionMessage, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
+	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage, skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
 	SignAndSubmitSnipe(ctx context.Context, transactions []*pb.TransactionMessage, useStakedRPCs bool) ([]string, error)
 	SignAndSubmitPaladin(ctx context.Context, tx *pb.TransactionMessage, revertProtection *bool) (string, error)
+	PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error)
 	PostSubmitBatch(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
 	PostSubmitV2(ctx context.Context, tx *pb.TransactionMessage, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
 	PostSubmitBatchV2(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
@@ -26,6 +28,13 @@ type GRPCClientTraderAPISubmitOnly interface {
 }
 
 type GRPCClientTraderAPI interface {
+	GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error)
+	PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error)
+	PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error)
+	GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error)
+	PostRaydiumCLMMRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest) (*pb.PostRaydiumRouteSwapResponse, error)
+	PostRaydiumCLMMSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest) (*pb.PostRaydiumSwapResponse, error)
+	PostRaydiumCPMMSwap(ctx context.Context, request *pb.PostRaydiumCPMMSwapRequest) (*pb.PostRaydiumCPMMSwapResponse, error)
 	RecentBlockHash(ctx context.Context) (*pb.GetRecentBlockHashResponse, error)
 	GetRecentBlockHash(ctx context.Context) (*pb.GetRecentBlockHashResponse, error)
 	GetRecentBlockHashV2(ctx context.Context, offset uint64) (*pb.GetRecentBlockHashResponseV2, error)
@@ -297,7 +306,7 @@ func NewGRPCClientWithOpts(opts RPCOpts, dialOpts ...grpc.DialOption) (*GRPCClie
 	}
 	grpcOpts = append(grpcOpts, grpc.WithDefaultCallOptions(&grpc.MaxRecvMsgSizeCallOption{MaxRecvMsgSize: 1024 * 1024 * 16}))
 	grpcOpts = append(grpcOpts, dialOpts...)
-	conn, err = grpc.Dial(opts.Endpoint, grpcOpts...)
+	conn, err = grpc.NewClient(opts.Endpoint, grpcOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/http.go
+++ b/provider/http.go
@@ -13,27 +13,75 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
-// GetRaydiumCLMMQuotes returns the CLMM quotes on Raydium
-func (h *HTTPClient) GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRaydiumCLMMQuotesRequest) (*pb.GetRaydiumCLMMQuotesResponse, error) {
-	url := fmt.Sprintf("%s/api/v2/raydium/clmm-quotes?inToken=%s&outToken=%s&inAmount=%v&slippage=%v",
-		h.baseURL, request.InToken, request.OutToken, request.InAmount, request.Slippage)
-	response := new(pb.GetRaydiumCLMMQuotesResponse)
-	if err := connections.HTTPGetWithClient[*pb.GetRaydiumCLMMQuotesResponse](ctx, url, h.httpClient, response, h.authHeader); err != nil {
+// Get the server time
+func (h *HTTPClient) GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error) {
+	url := fmt.Sprintf("%s/api/v1/system/time", h.baseURL)
+	response := new(pb.GetServerTimeResponse)
+	if err := connections.HTTPGetWithClient[*pb.GetServerTimeResponse](ctx, url, h.httpClient, response, h.authHeader); err != nil {
 		return nil, err
 	}
 
 	return response, nil
 }
 
-// GetRaydiumCLMMPools returns the CLMM pools on Raydium
-func (h *HTTPClient) GetRaydiumCLMMPools(ctx context.Context, request *pb.GetRaydiumCLMMPoolsRequest) (*pb.GetRaydiumCLMMPoolsResponse, error) {
-	url := fmt.Sprintf("%s/api/v2/raydium/clmm-pools?pairOrAddress=%s", h.baseURL, request.PairOrAddress)
-	pools := new(pb.GetRaydiumCLMMPoolsResponse)
-	if err := connections.HTTPGetWithClient[*pb.GetRaydiumCLMMPoolsResponse](ctx, url, h.httpClient, pools, h.authHeader); err != nil {
+// Submit transaction to Paladin validator
+func (h *HTTPClient) PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error) {
+	url := fmt.Sprintf("%s/api/v2/submit-paladin", h.baseURL)
+	var response pb.PostSubmitResponse
+	err := connections.HTTPPostWithClient[*pb.PostSubmitResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	if err != nil {
 		return nil, err
 	}
 
-	return pools, nil
+	return &response, nil
+}
+
+// Post a transaction to Pump Fun in sol
+func (h *HTTPClient) PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error) {
+	url := fmt.Sprintf("%s/api/v2/pumpfun/swap-sol", h.baseURL)
+	var response pb.PostPumpFunSwapResponse
+	err := connections.HTTPPostWithClient[*pb.PostPumpFunSwapResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// Get quote for Raydium CPMM pool
+func (h *HTTPClient) GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error) {
+	url := fmt.Sprintf("%s/api/v2/raydium/cpmm-quotes", h.baseURL)
+	var response pb.GetRaydiumCPMMQuotesResponse
+	err := connections.HTTPPostWithClient[*pb.GetRaydiumCPMMQuotesResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// GetRaydiumCLMMQuotes returns the CLMM quotes on Raydium
+func (h *HTTPClient) GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRaydiumCLMMQuotesRequest) (*pb.GetRaydiumCLMMQuotesResponse, error) {
+	url := fmt.Sprintf("%s/api/v2/raydium/clmm-quotes", h.baseURL)
+	var response pb.GetRaydiumCLMMQuotesResponse
+	err := connections.HTTPPostWithClient[*pb.GetRaydiumCLMMQuotesResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// GetRaydiumCLMMPools returns the CLMM pools on Raydium
+func (h *HTTPClient) GetRaydiumCLMMPools(ctx context.Context, request *pb.GetRaydiumCLMMPoolsRequest) (*pb.GetRaydiumCLMMPoolsResponse, error) {
+	url := fmt.Sprintf("%s/api/v2/raydium/clmm-pools", h.baseURL)
+	var response pb.GetRaydiumCLMMPoolsResponse
+	err := connections.HTTPPostWithClient[*pb.GetRaydiumCLMMPoolsResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
 }
 
 // PostRaydiumCLMMSwap returns a partially signed transaction(s) for submitting a swap request on Raydium

--- a/provider/http.go
+++ b/provider/http.go
@@ -50,9 +50,9 @@ func (h *HTTPClient) PostPumpFunSwapSol(ctx context.Context, request *pb.PostPum
 
 // Get quote for Raydium CPMM pool
 func (h *HTTPClient) GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error) {
-	url := fmt.Sprintf("%s/api/v2/raydium/cpmm-quotes", h.baseURL)
+	url := fmt.Sprintf("%s/api/v2/raydium/cpmm-quotes?inToken=%s&outToken=%s&inAmount=%f&slippage=%f", h.baseURL, request.InToken, request.OutToken, request.InAmount, request.Slippage)
 	var response pb.GetRaydiumCPMMQuotesResponse
-	err := connections.HTTPPostWithClient[*pb.GetRaydiumCPMMQuotesResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	err := connections.HTTPGetWithClient[*pb.GetRaydiumCPMMQuotesResponse](ctx, url, h.httpClient, &response, h.authHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -62,9 +62,9 @@ func (h *HTTPClient) GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRa
 
 // GetRaydiumCLMMQuotes returns the CLMM quotes on Raydium
 func (h *HTTPClient) GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRaydiumCLMMQuotesRequest) (*pb.GetRaydiumCLMMQuotesResponse, error) {
-	url := fmt.Sprintf("%s/api/v2/raydium/clmm-quotes", h.baseURL)
+	url := fmt.Sprintf("%s/api/v2/raydium/clmm-quotes?inToken=%s&outToken=%s&inAmount=%f&slippage=%f", h.baseURL, request.InToken, request.OutToken, request.InAmount, request.Slippage)
 	var response pb.GetRaydiumCLMMQuotesResponse
-	err := connections.HTTPPostWithClient[*pb.GetRaydiumCLMMQuotesResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	err := connections.HTTPGetWithClient[*pb.GetRaydiumCLMMQuotesResponse](ctx, url, h.httpClient, &response, h.authHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -74,9 +74,9 @@ func (h *HTTPClient) GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRa
 
 // GetRaydiumCLMMPools returns the CLMM pools on Raydium
 func (h *HTTPClient) GetRaydiumCLMMPools(ctx context.Context, request *pb.GetRaydiumCLMMPoolsRequest) (*pb.GetRaydiumCLMMPoolsResponse, error) {
-	url := fmt.Sprintf("%s/api/v2/raydium/clmm-pools", h.baseURL)
+	url := fmt.Sprintf("%s/api/v2/raydium/clmm-pools?pairOrAddress=%s", h.baseURL, request.PairOrAddress)
 	var response pb.GetRaydiumCLMMPoolsResponse
-	err := connections.HTTPPostWithClient[*pb.GetRaydiumCLMMPoolsResponse](ctx, url, h.httpClient, request, &response, h.authHeader)
+	err := connections.HTTPGetWithClient[*pb.GetRaydiumCLMMPoolsResponse](ctx, url, h.httpClient, &response, h.authHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/http_interfaces.go
+++ b/provider/http_interfaces.go
@@ -3,14 +3,18 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/bloXroute-Labs/solana-trader-client-go/utils"
+	"net/http"
+
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 	"github.com/bloXroute-Labs/solana-trader-proto/common"
 	"github.com/gagliardetto/solana-go"
-	"net/http"
 )
 
 type HTTPClientTraderAPI interface {
+	GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error)
+	PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error)
+	PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error)
+	GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error)
 	GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRaydiumCLMMQuotesRequest) (*pb.GetRaydiumCLMMQuotesResponse, error)
 	GetRaydiumCLMMPools(ctx context.Context, request *pb.GetRaydiumCLMMPoolsRequest) (*pb.GetRaydiumCLMMPoolsResponse, error)
 	PostRaydiumCLMMSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest) (*pb.PostRaydiumSwapResponse, error)
@@ -167,12 +171,10 @@ type HTTPClientTraderAPISubmitOnly interface {
 	PostSubmitBatch(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
 	PostSubmitV2(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
 	PostSubmitBatchV2(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
-	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage,
-		skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
+	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage, skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
 	SignAndSubmitSnipe(ctx context.Context, transactions []*pb.TransactionMessage, useStakedRPCs bool) ([]string, error)
 	SignAndSubmitPaladin(ctx context.Context, tx *pb.TransactionMessage, revertProtection *bool) (string, error)
-	SignAndSubmitBatch(ctx context.Context, transactions []*pb.TransactionMessage, useBundle bool,
-		opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SignAndSubmitBatch(ctx context.Context, transactions []*pb.TransactionMessage, useBundle bool, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
 }
 
 type HTTPClient struct {
@@ -180,7 +182,6 @@ type HTTPClient struct {
 
 	baseURL    string
 	httpClient *http.Client
-	requestID  utils.RequestID
 	privateKey *solana.PrivateKey
 	authHeader string
 }

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -13,6 +13,57 @@ import (
 	"github.com/gagliardetto/solana-go"
 )
 
+// Get the current server time
+func (w *WSClient) GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error) {
+	var response pb.GetServerTimeResponse
+	err := w.conn.Request(ctx, "GetServerTime", request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Post and Submit a transaction to a Paladin validator
+func (w *WSClient) PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error) {
+	var response pb.PostSubmitResponse
+	err := w.conn.Request(ctx, "PostSubmitPaladinV2", request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Post a Pump Swap transaction in SOL
+func (w *WSClient) PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error) {
+	var response pb.PostPumpFunSwapResponse
+	err := w.conn.Request(ctx, "PostPumpFunSwapSol", request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Get quotes for Raydium CPMM pool
+func (w *WSClient) GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error) {
+	var response pb.GetRaydiumCPMMQuotesResponse
+	err := w.conn.Request(ctx, "GetRaydiumCPMMQuotes", request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Post a Raydium CPMM pool swap
+func (w *WSClient) PostRaydiumCPMMSwap(ctx context.Context, request *pb.PostRaydiumCPMMSwapRequest) (*pb.PostRaydiumCPMMSwapResponse, error) {
+	var response pb.PostRaydiumCPMMSwapResponse
+	err := w.conn.Request(ctx, "PostRaydiumCPMMSwap", request, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// Get the most recently cached block hash
 func (w *WSClient) RecentBlockHash(ctx context.Context) (*pb.GetRecentBlockHashResponse, error) {
 	return w.recentBlockHashStore.get(ctx)
 }

--- a/provider/ws_interfaces.go
+++ b/provider/ws_interfaces.go
@@ -3,113 +3,118 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
-	"github.com/bloXroute-Labs/solana-trader-proto/api"
+	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 	"github.com/bloXroute-Labs/solana-trader-proto/common"
 	"github.com/gagliardetto/solana-go"
 )
 
 type WSClientTraderAPISubmitOnly interface {
-	PostSubmit(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*api.PostSubmitResponse, error)
-	PostSubmitSnipeV2(ctx context.Context, request *api.PostSubmitSnipeRequest) (*api.PostSubmitSnipeResponse, error)
-	PostSubmitBatch(ctx context.Context, request *api.PostSubmitBatchRequest) (*api.PostSubmitBatchResponse, error)
-	PostSubmitV2(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*api.PostSubmitResponse, error)
-	PostSubmitBatchV2(ctx context.Context, request *api.PostSubmitBatchRequest) (*api.PostSubmitBatchResponse, error)
-	SignAndSubmit(ctx context.Context, tx *api.TransactionMessage,
-		skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
-	SignAndSubmitSnipe(ctx context.Context, transactions []*api.TransactionMessage, useStakedRPCs bool) ([]string, error)
-	SignAndSubmitPaladin(ctx context.Context, tx *api.TransactionMessage, revertProtection *bool) (string, error)
-	SignAndSubmitBatch(ctx context.Context, transactions []*api.TransactionMessage, useBundle bool, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
+	PostSubmit(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
+	PostSubmitSnipeV2(ctx context.Context, request *pb.PostSubmitSnipeRequest) (*pb.PostSubmitSnipeResponse, error)
+	PostSubmitBatch(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
+	PostSubmitV2(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
+	PostSubmitBatchV2(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
+	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage, skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
+	SignAndSubmitSnipe(ctx context.Context, transactions []*pb.TransactionMessage, useStakedRPCs bool) ([]string, error)
+	SignAndSubmitPaladin(ctx context.Context, tx *pb.TransactionMessage, revertProtection *bool) (string, error)
+	SignAndSubmitBatch(ctx context.Context, transactions []*pb.TransactionMessage, useBundle bool, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
 }
 
 type WSClientTraderAPI interface {
-	RecentBlockHash(ctx context.Context) (*api.GetRecentBlockHashResponse, error)
-	GetTransaction(ctx context.Context, request *api.GetTransactionRequest) (*api.GetTransactionResponse, error)
-	GetRateLimit(ctx context.Context, request *api.GetRateLimitRequest) (*api.GetRateLimitResponse, error)
-	GetRaydiumPoolReserve(ctx context.Context, req *api.GetRaydiumPoolReserveRequest) (*api.GetRaydiumPoolReserveResponse, error)
-	GetRaydiumPools(ctx context.Context, request *api.GetRaydiumPoolsRequest) (*api.GetRaydiumPoolsResponse, error)
-	GetRaydiumQuotes(ctx context.Context, request *api.GetRaydiumQuotesRequest) (*api.GetRaydiumQuotesResponse, error)
-	GetRaydiumQuotesCPMM(ctx context.Context, request *api.GetRaydiumCPMMQuotesRequest) (*api.GetRaydiumCPMMQuotesResponse, error)
-	GetPumpFunQuotes(ctx context.Context, request *api.GetPumpFunQuotesRequest) (*api.GetPumpFunQuotesResponse, error)
-	GetRaydiumPrices(ctx context.Context, request *api.GetRaydiumPricesRequest) (*api.GetRaydiumPricesResponse, error)
-	GetRaydiumCLMMQuotes(ctx context.Context, request *api.GetRaydiumCLMMQuotesRequest) (*api.GetRaydiumCLMMQuotesResponse, error)
-	GetRaydiumCLMMPools(ctx context.Context, request *api.GetRaydiumCLMMPoolsRequest) (*api.GetRaydiumCLMMPoolsResponse, error)
-	PostRaydiumCLMMSwap(ctx context.Context, request *api.PostRaydiumSwapRequest) (*api.PostRaydiumSwapResponse, error)
-	PostRaydiumCLMMRouteSwap(ctx context.Context, request *api.PostRaydiumRouteSwapRequest) (*api.PostRaydiumRouteSwapResponse, error)
-	PostRaydiumSwap(ctx context.Context, request *api.PostRaydiumSwapRequest) (*api.PostRaydiumSwapResponse, error)
-	PostRaydiumSwapCPMM(ctx context.Context, request *api.PostRaydiumCPMMSwapRequest) (*api.PostRaydiumCPMMSwapResponse, error)
-	PostPumpFunSwap(ctx context.Context, request *api.PostPumpFunSwapRequest) (*api.PostPumpFunSwapResponse, error)
-	PostRaydiumRouteSwap(ctx context.Context, request *api.PostRaydiumRouteSwapRequest) (*api.PostRaydiumRouteSwapResponse, error)
-	SubmitRaydiumCLMMSwap(ctx context.Context, request *api.PostRaydiumSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitRaydiumCLMMRouteSwap(ctx context.Context, request *api.PostRaydiumRouteSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	GetJupiterQuotes(ctx context.Context, request *api.GetJupiterQuotesRequest) (*api.GetJupiterQuotesResponse, error)
-	GetJupiterPrices(ctx context.Context, request *api.GetJupiterPricesRequest) (*api.GetJupiterPricesResponse, error)
-	PostJupiterSwap(ctx context.Context, request *api.PostJupiterSwapRequest) (*api.PostJupiterSwapResponse, error)
-	PostJupiterSwapInstructions(ctx context.Context, request *api.PostJupiterSwapInstructionsRequest) (*api.PostJupiterSwapInstructionsResponse, error)
-	PostRaydiumSwapInstructions(ctx context.Context, request *api.PostRaydiumSwapInstructionsRequest) (*api.PostRaydiumSwapInstructionsResponse, error)
-	PostJupiterRouteSwap(ctx context.Context, request *api.PostJupiterRouteSwapRequest) (*api.PostJupiterRouteSwapResponse, error)
-	GetOrderbook(ctx context.Context, market string, limit uint32, project api.Project) (*api.GetOrderbookResponse, error)
-	GetMarketDepth(ctx context.Context, market string, limit uint32, project api.Project) (*api.GetMarketDepthResponse, error)
-	GetTrades(ctx context.Context, market string, limit uint32, project api.Project) (*api.GetTradesResponse, error)
-	GetPools(ctx context.Context, projects []api.Project) (*api.GetPoolsResponse, error)
-	GetTickers(ctx context.Context, market string, project api.Project) (*api.GetTickersResponse, error)
-	GetOpenOrders(ctx context.Context, market string, owner string, openOrdersAddress string, project api.Project) (*api.GetOpenOrdersResponse, error)
-	GetOrderByID(ctx context.Context, in *api.GetOrderByIDRequest) (*api.GetOrderByIDResponse, error)
-	GetUnsettled(ctx context.Context, market string, ownerAddress string, project api.Project) (*api.GetUnsettledResponse, error)
-	GetAccountBalance(ctx context.Context, owner string) (*api.GetAccountBalanceResponse, error)
-	GetTokenAccounts(ctx context.Context, req *api.GetTokenAccountsRequest) (*api.GetTokenAccountsResponse, error)
-	GetMarkets(ctx context.Context) (*api.GetMarketsResponse, error)
-	GetPrice(ctx context.Context, tokens []string) (*api.GetPriceResponse, error)
-	GetQuotes(ctx context.Context, inToken, outToken string, inAmount, slippage float64, limit int32, projects []api.Project) (*api.GetQuotesResponse, error)
-	GetPriorityFee(ctx context.Context, project api.Project, percentile *float64) (*api.GetPriorityFeeResponse, error)
-	GetPriorityFeeByProgram(ctx context.Context, programs []string) (*api.GetPriorityFeeByProgramResponse, error)
-	GetLeaderSchedule(ctx context.Context, maxSlots uint64) (*api.GetLeaderScheduleResponse, error)
-	PostTradeSwap(ctx context.Context, ownerAddress, inToken, outToken string, inAmount, slippage float64, projectStr string) (*api.TradeSwapResponse, error)
+	GetServerTime(ctx context.Context, request *pb.GetServerTimeRequest) (*pb.GetServerTimeResponse, error)
+	PostSubmitPaladinV2(ctx context.Context, request *pb.PostSubmitPaladinRequest) (*pb.PostSubmitResponse, error)
+	PostPumpFunSwapSol(ctx context.Context, request *pb.PostPumpFunSwapRequestSol) (*pb.PostPumpFunSwapResponse, error)
+	GetRaydiumCPMMQuotes(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error)
+	PostRaydiumCPMMSwap(ctx context.Context, request *pb.PostRaydiumCPMMSwapRequest) (*pb.PostRaydiumCPMMSwapResponse, error)
+	RecentBlockHash(ctx context.Context) (*pb.GetRecentBlockHashResponse, error)
+	GetTransaction(ctx context.Context, request *pb.GetTransactionRequest) (*pb.GetTransactionResponse, error)
+	GetRateLimit(ctx context.Context, request *pb.GetRateLimitRequest) (*pb.GetRateLimitResponse, error)
+	GetRaydiumPoolReserve(ctx context.Context, req *pb.GetRaydiumPoolReserveRequest) (*pb.GetRaydiumPoolReserveResponse, error)
+	GetRaydiumPools(ctx context.Context, request *pb.GetRaydiumPoolsRequest) (*pb.GetRaydiumPoolsResponse, error)
+	GetRaydiumQuotes(ctx context.Context, request *pb.GetRaydiumQuotesRequest) (*pb.GetRaydiumQuotesResponse, error)
+	GetRaydiumQuotesCPMM(ctx context.Context, request *pb.GetRaydiumCPMMQuotesRequest) (*pb.GetRaydiumCPMMQuotesResponse, error)
+	GetPumpFunQuotes(ctx context.Context, request *pb.GetPumpFunQuotesRequest) (*pb.GetPumpFunQuotesResponse, error)
+	GetRaydiumPrices(ctx context.Context, request *pb.GetRaydiumPricesRequest) (*pb.GetRaydiumPricesResponse, error)
+	GetRaydiumCLMMQuotes(ctx context.Context, request *pb.GetRaydiumCLMMQuotesRequest) (*pb.GetRaydiumCLMMQuotesResponse, error)
+	GetRaydiumCLMMPools(ctx context.Context, request *pb.GetRaydiumCLMMPoolsRequest) (*pb.GetRaydiumCLMMPoolsResponse, error)
+	PostRaydiumCLMMSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest) (*pb.PostRaydiumSwapResponse, error)
+	PostRaydiumCLMMRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest) (*pb.PostRaydiumRouteSwapResponse, error)
+	PostRaydiumSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest) (*pb.PostRaydiumSwapResponse, error)
+	PostRaydiumSwapCPMM(ctx context.Context, request *pb.PostRaydiumCPMMSwapRequest) (*pb.PostRaydiumCPMMSwapResponse, error)
+	PostPumpFunSwap(ctx context.Context, request *pb.PostPumpFunSwapRequest) (*pb.PostPumpFunSwapResponse, error)
+	PostRaydiumRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest) (*pb.PostRaydiumRouteSwapResponse, error)
+	SubmitRaydiumCLMMSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitRaydiumCLMMRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	GetJupiterQuotes(ctx context.Context, request *pb.GetJupiterQuotesRequest) (*pb.GetJupiterQuotesResponse, error)
+	GetJupiterPrices(ctx context.Context, request *pb.GetJupiterPricesRequest) (*pb.GetJupiterPricesResponse, error)
+	PostJupiterSwap(ctx context.Context, request *pb.PostJupiterSwapRequest) (*pb.PostJupiterSwapResponse, error)
+	PostJupiterSwapInstructions(ctx context.Context, request *pb.PostJupiterSwapInstructionsRequest) (*pb.PostJupiterSwapInstructionsResponse, error)
+	PostRaydiumSwapInstructions(ctx context.Context, request *pb.PostRaydiumSwapInstructionsRequest) (*pb.PostRaydiumSwapInstructionsResponse, error)
+	PostJupiterRouteSwap(ctx context.Context, request *pb.PostJupiterRouteSwapRequest) (*pb.PostJupiterRouteSwapResponse, error)
+	GetOrderbook(ctx context.Context, market string, limit uint32, project pb.Project) (*pb.GetOrderbookResponse, error)
+	GetMarketDepth(ctx context.Context, market string, limit uint32, project pb.Project) (*pb.GetMarketDepthResponse, error)
+	GetTrades(ctx context.Context, market string, limit uint32, project pb.Project) (*pb.GetTradesResponse, error)
+	GetPools(ctx context.Context, projects []pb.Project) (*pb.GetPoolsResponse, error)
+	GetTickers(ctx context.Context, market string, project pb.Project) (*pb.GetTickersResponse, error)
+	GetOpenOrders(ctx context.Context, market string, owner string, openOrdersAddress string, project pb.Project) (*pb.GetOpenOrdersResponse, error)
+	GetOrderByID(ctx context.Context, in *pb.GetOrderByIDRequest) (*pb.GetOrderByIDResponse, error)
+	GetUnsettled(ctx context.Context, market string, ownerAddress string, project pb.Project) (*pb.GetUnsettledResponse, error)
+	GetAccountBalance(ctx context.Context, owner string) (*pb.GetAccountBalanceResponse, error)
+	GetTokenAccounts(ctx context.Context, req *pb.GetTokenAccountsRequest) (*pb.GetTokenAccountsResponse, error)
+	GetMarkets(ctx context.Context) (*pb.GetMarketsResponse, error)
+	GetPrice(ctx context.Context, tokens []string) (*pb.GetPriceResponse, error)
+	GetQuotes(ctx context.Context, inToken, outToken string, inAmount, slippage float64, limit int32, projects []pb.Project) (*pb.GetQuotesResponse, error)
+	GetPriorityFee(ctx context.Context, project pb.Project, percentile *float64) (*pb.GetPriorityFeeResponse, error)
+	GetPriorityFeeByProgram(ctx context.Context, programs []string) (*pb.GetPriorityFeeByProgramResponse, error)
+	GetLeaderSchedule(ctx context.Context, maxSlots uint64) (*pb.GetLeaderScheduleResponse, error)
+	PostTradeSwap(ctx context.Context, ownerAddress, inToken, outToken string, inAmount, slippage float64, projectStr string) (*pb.TradeSwapResponse, error)
 	PostTradeSwapWithPriorityFee(ctx context.Context, ownerAddress, inToken, outToken string, inAmount,
-		slippage float64, computeLimit uint32, computePrice uint64, projectStr string) (*api.TradeSwapResponse, error)
-	PostRouteTradeSwap(ctx context.Context, request *api.RouteTradeSwapRequest) (*api.TradeSwapResponse, error)
-	PostOrder(ctx context.Context, owner, payer, market string, side api.Side, types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (*api.PostOrderResponse, error)
-	PostSubmit(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*api.PostSubmitResponse, error)
-	PostSubmitSnipeV2(ctx context.Context, request *api.PostSubmitSnipeRequest) (*api.PostSubmitSnipeResponse, error)
-	PostSubmitBatch(ctx context.Context, request *api.PostSubmitBatchRequest) (*api.PostSubmitBatchResponse, error)
-	PostSubmitV2(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*api.PostSubmitResponse, error)
-	PostSubmitBatchV2(ctx context.Context, request *api.PostSubmitBatchRequest) (*api.PostSubmitBatchResponse, error)
-	SignAndSubmit(ctx context.Context, tx *api.TransactionMessage,
+		slippage float64, computeLimit uint32, computePrice uint64, projectStr string) (*pb.TradeSwapResponse, error)
+	PostRouteTradeSwap(ctx context.Context, request *pb.RouteTradeSwapRequest) (*pb.TradeSwapResponse, error)
+	PostOrder(ctx context.Context, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (*pb.PostOrderResponse, error)
+	PostSubmit(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
+	PostSubmitSnipeV2(ctx context.Context, request *pb.PostSubmitSnipeRequest) (*pb.PostSubmitSnipeResponse, error)
+	PostSubmitBatch(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
+	PostSubmitV2(ctx context.Context, txBase64 string, opts PostSubmitOpts) (*pb.PostSubmitResponse, error)
+	PostSubmitBatchV2(ctx context.Context, request *pb.PostSubmitBatchRequest) (*pb.PostSubmitBatchResponse, error)
+	SignAndSubmit(ctx context.Context, tx *pb.TransactionMessage,
 		skipPreFlight bool, frontRunningProtection bool, useStakedRPCs bool) (string, error)
-	SignAndSubmitSnipe(ctx context.Context, transactions []*api.TransactionMessage, useStakedRPCs bool) ([]string, error)
-	SignAndSubmitPaladin(ctx context.Context, tx *api.TransactionMessage, revertProtection *bool) (string, error)
-	SignAndSubmitBatch(ctx context.Context, transactions []*api.TransactionMessage, useBundle bool, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitTradeSwap(ctx context.Context, owner, inToken, outToken string, inAmount, slippage float64, project string, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
+	SignAndSubmitSnipe(ctx context.Context, transactions []*pb.TransactionMessage, useStakedRPCs bool) ([]string, error)
+	SignAndSubmitPaladin(ctx context.Context, tx *pb.TransactionMessage, revertProtection *bool) (string, error)
+	SignAndSubmitBatch(ctx context.Context, transactions []*pb.TransactionMessage, useBundle bool, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitTradeSwap(ctx context.Context, owner, inToken, outToken string, inAmount, slippage float64, project string, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
 	SubmitTradeSwapWithPriorityFee(ctx context.Context, owner, inToken, outToken string,
-		inAmount, slippage float64, project string, computeLimit uint32, computePrice uint64, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitRouteTradeSwap(ctx context.Context, request *api.RouteTradeSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitRaydiumSwap(ctx context.Context, request *api.PostRaydiumSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitRaydiumSwapCPMM(ctx context.Context, request *api.PostRaydiumCPMMSwapRequest) (string, error)
-	SubmitPostPumpFunSwap(ctx context.Context, request *api.PostPumpFunSwapRequest) (string, error)
-	SubmitRaydiumRouteSwap(ctx context.Context, request *api.PostRaydiumRouteSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitJupiterSwap(ctx context.Context, request *api.PostJupiterSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitJupiterSwapInstructions(ctx context.Context, request *api.PostJupiterSwapInstructionsRequest, useBundle bool, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitRaydiumSwapInstructions(ctx context.Context, request *api.PostRaydiumSwapInstructionsRequest, useBundle bool, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitJupiterRouteSwap(ctx context.Context, request *api.PostJupiterRouteSwapRequest, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	SubmitOrder(ctx context.Context, owner, payer, market string, side api.Side,
-		types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (string, error)
-	PostCancelOrder(ctx context.Context, request *api.PostCancelOrderRequest) (*api.PostCancelOrderResponse, error)
-	SubmitCancelOrder(ctx context.Context, request *api.PostCancelOrderRequest, skipPreFlight bool) (string, error)
+		inAmount, slippage float64, project string, computeLimit uint32, computePrice uint64, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitRouteTradeSwap(ctx context.Context, request *pb.RouteTradeSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitRaydiumSwap(ctx context.Context, request *pb.PostRaydiumSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitRaydiumSwapCPMM(ctx context.Context, request *pb.PostRaydiumCPMMSwapRequest) (string, error)
+	SubmitPostPumpFunSwap(ctx context.Context, request *pb.PostPumpFunSwapRequest) (string, error)
+	SubmitRaydiumRouteSwap(ctx context.Context, request *pb.PostRaydiumRouteSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitJupiterSwap(ctx context.Context, request *pb.PostJupiterSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitJupiterSwapInstructions(ctx context.Context, request *pb.PostJupiterSwapInstructionsRequest, useBundle bool, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitRaydiumSwapInstructions(ctx context.Context, request *pb.PostRaydiumSwapInstructionsRequest, useBundle bool, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitJupiterRouteSwap(ctx context.Context, request *pb.PostJupiterRouteSwapRequest, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	SubmitOrder(ctx context.Context, owner, payer, market string, side pb.Side,
+		types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (string, error)
+	PostCancelOrder(ctx context.Context, request *pb.PostCancelOrderRequest) (*pb.PostCancelOrderResponse, error)
+	SubmitCancelOrder(ctx context.Context, request *pb.PostCancelOrderRequest, skipPreFlight bool) (string, error)
 	PostCancelByClientOrderID(
 		ctx context.Context,
 		clientOrderID uint64,
 		owner,
 		market,
 		openOrders string,
-		project api.Project,
-	) (*api.PostCancelOrderResponse, error)
+		project pb.Project,
+	) (*pb.PostCancelOrderResponse, error)
 	SubmitCancelByClientOrderID(
 		ctx context.Context,
 		clientOrderID uint64,
 		owner,
 		market,
 		openOrders string,
-		project api.Project,
+		project pb.Project,
 		skipPreFlight bool,
 	) (string, error)
 	PostCancelAll(
@@ -117,60 +122,60 @@ type WSClientTraderAPI interface {
 		market,
 		owner string,
 		openOrdersAddresses []string,
-		project api.Project,
-	) (*api.PostCancelAllResponse, error)
-	SubmitCancelAll(ctx context.Context, market, owner string, openOrdersAddresses []string, project api.Project, opts SubmitOpts) (*api.PostSubmitBatchResponse, error)
-	PostSettle(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string, project api.Project) (*api.PostSettleResponse, error)
-	SubmitSettle(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string, project api.Project, skipPreflight bool) (string, error)
-	PostReplaceByClientOrderID(ctx context.Context, owner, payer, market string, side api.Side, types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (*api.PostOrderResponse, error)
-	SubmitReplaceByClientOrderID(ctx context.Context, owner, payer, market string, side api.Side, types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (string, error)
-	PostReplaceOrder(ctx context.Context, orderID, owner, payer, market string, side api.Side, types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (*api.PostOrderResponse, error)
-	SubmitReplaceOrder(ctx context.Context, orderID, owner, payer, market string, side api.Side, types []common.OrderType, amount, price float64, project api.Project, opts PostOrderOpts) (string, error)
+		project pb.Project,
+	) (*pb.PostCancelAllResponse, error)
+	SubmitCancelAll(ctx context.Context, market, owner string, openOrdersAddresses []string, project pb.Project, opts SubmitOpts) (*pb.PostSubmitBatchResponse, error)
+	PostSettle(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string, project pb.Project) (*pb.PostSettleResponse, error)
+	SubmitSettle(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string, project pb.Project, skipPreflight bool) (string, error)
+	PostReplaceByClientOrderID(ctx context.Context, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (*pb.PostOrderResponse, error)
+	SubmitReplaceByClientOrderID(ctx context.Context, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (string, error)
+	PostReplaceOrder(ctx context.Context, orderID, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (*pb.PostOrderResponse, error)
+	SubmitReplaceOrder(ctx context.Context, orderID, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (string, error)
 	Close() error
-	GetOrderbooksStream(ctx context.Context, markets []string, limit uint32, project api.Project) (connections.Streamer[*api.GetOrderbooksStreamResponse], error)
-	GetPumpFunSwapsStream(ctx context.Context, req *api.GetPumpFunSwapsStreamRequest) (connections.Streamer[*api.GetPumpFunSwapsStreamResponse], error)
-	GetPumpFunNewTokensStream(ctx context.Context, req *api.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*api.GetPumpFunNewTokensStreamResponse], error)
-	GetMarketDepthsStream(ctx context.Context, markets []string, limit uint32, project api.Project) (connections.Streamer[*api.GetMarketDepthsStreamResponse], error)
-	GetTradesStream(ctx context.Context, market string, limit uint32, project api.Project) (connections.Streamer[*api.GetTradesStreamResponse], error)
-	GetNewRaydiumPoolsStream(ctx context.Context, includeCPMM bool) (connections.Streamer[*api.GetNewRaydiumPoolsResponse], error)
-	GetNewRaydiumPoolsByTransactionStream(ctx context.Context) (connections.Streamer[*api.GetNewRaydiumPoolsByTransactionResponse], error)
-	GetOrderStatusStream(ctx context.Context, market, ownerAddress string, project api.Project) (connections.Streamer[*api.GetOrderStatusStreamResponse], error)
-	GetRecentBlockHashStream(ctx context.Context) (connections.Streamer[*api.GetRecentBlockHashResponse], error)
-	GetQuotesStream(ctx context.Context, projects []api.Project, tokenPairs []*api.TokenPair) (connections.Streamer[*api.GetQuotesStreamResponse], error)
-	GetPoolReservesStream(ctx context.Context, request *api.GetPoolReservesStreamRequest) (connections.Streamer[*api.GetPoolReservesStreamResponse], error)
-	GetPricesStream(ctx context.Context, projects []api.Project, tokens []string) (connections.Streamer[*api.GetPricesStreamResponse], error)
-	GetTickersStream(ctx context.Context, request *api.GetTickersStreamRequest) (connections.Streamer[*api.GetTickersStreamResponse], error)
+	GetOrderbooksStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error)
+	GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpFunSwapsStreamRequest) (connections.Streamer[*pb.GetPumpFunSwapsStreamResponse], error)
+	GetPumpFunNewTokensStream(ctx context.Context, req *pb.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*pb.GetPumpFunNewTokensStreamResponse], error)
+	GetMarketDepthsStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetMarketDepthsStreamResponse], error)
+	GetTradesStream(ctx context.Context, market string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetTradesStreamResponse], error)
+	GetNewRaydiumPoolsStream(ctx context.Context, includeCPMM bool) (connections.Streamer[*pb.GetNewRaydiumPoolsResponse], error)
+	GetNewRaydiumPoolsByTransactionStream(ctx context.Context) (connections.Streamer[*pb.GetNewRaydiumPoolsByTransactionResponse], error)
+	GetOrderStatusStream(ctx context.Context, market, ownerAddress string, project pb.Project) (connections.Streamer[*pb.GetOrderStatusStreamResponse], error)
+	GetRecentBlockHashStream(ctx context.Context) (connections.Streamer[*pb.GetRecentBlockHashResponse], error)
+	GetQuotesStream(ctx context.Context, projects []pb.Project, tokenPairs []*pb.TokenPair) (connections.Streamer[*pb.GetQuotesStreamResponse], error)
+	GetPoolReservesStream(ctx context.Context, request *pb.GetPoolReservesStreamRequest) (connections.Streamer[*pb.GetPoolReservesStreamResponse], error)
+	GetPricesStream(ctx context.Context, projects []pb.Project, tokens []string) (connections.Streamer[*pb.GetPricesStreamResponse], error)
+	GetTickersStream(ctx context.Context, request *pb.GetTickersStreamRequest) (connections.Streamer[*pb.GetTickersStreamResponse], error)
 	GetSwapsStream(
 		ctx context.Context,
-		projects []api.Project,
+		projects []pb.Project,
 		markets []string,
 		includeFailed bool,
-	) (connections.Streamer[*api.GetSwapsStreamResponse], error)
-	GetBlockStream(ctx context.Context) (connections.Streamer[*api.GetBlockStreamResponse], error)
-	GetPumpFunNewAmmPoolStream(ctx context.Context, req *api.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*api.GetPumpFunNewAmmPoolStreamResponse], error)
-	GetPriorityFeeStream(ctx context.Context, project api.Project, percentile *float64) (connections.Streamer[*api.GetPriorityFeeResponse], error)
-	GetPriorityFeeByProgramStream(ctx context.Context, programs []string) (connections.Streamer[*api.GetPriorityFeeByProgramResponse], error)
-	GetBundleTipStream(ctx context.Context) (connections.Streamer[*api.GetBundleTipResponse], error)
-	GetMarketsV2(ctx context.Context) (*api.GetMarketsResponse, error)
-	GetOrderbookV2(ctx context.Context, market string, limit uint32) (*api.GetOrderbookResponseV2, error)
-	GetMarketDepthV2(ctx context.Context, market string, limit uint32) (*api.GetMarketDepthResponseV2, error)
-	GetTickersV2(ctx context.Context, market string) (*api.GetTickersResponseV2, error)
-	GetOpenOrdersV2(ctx context.Context, market string, owner string, openOrdersAddress string, orderID string, clientOrderID uint64) (*api.GetOpenOrdersResponse, error)
-	GetUnsettledV2(ctx context.Context, market string, ownerAddress string) (*api.GetUnsettledResponse, error)
-	PostOrderV2(ctx context.Context, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (*api.PostOrderResponse, error)
+	) (connections.Streamer[*pb.GetSwapsStreamResponse], error)
+	GetBlockStream(ctx context.Context) (connections.Streamer[*pb.GetBlockStreamResponse], error)
+	GetPumpFunNewAmmPoolStream(ctx context.Context, req *pb.GetPumpFunNewAmmPoolStreamRequest) (connections.Streamer[*pb.GetPumpFunNewAmmPoolStreamResponse], error)
+	GetPriorityFeeStream(ctx context.Context, project pb.Project, percentile *float64) (connections.Streamer[*pb.GetPriorityFeeResponse], error)
+	GetPriorityFeeByProgramStream(ctx context.Context, programs []string) (connections.Streamer[*pb.GetPriorityFeeByProgramResponse], error)
+	GetBundleTipStream(ctx context.Context) (connections.Streamer[*pb.GetBundleTipResponse], error)
+	GetMarketsV2(ctx context.Context) (*pb.GetMarketsResponse, error)
+	GetOrderbookV2(ctx context.Context, market string, limit uint32) (*pb.GetOrderbookResponseV2, error)
+	GetMarketDepthV2(ctx context.Context, market string, limit uint32) (*pb.GetMarketDepthResponseV2, error)
+	GetTickersV2(ctx context.Context, market string) (*pb.GetTickersResponseV2, error)
+	GetOpenOrdersV2(ctx context.Context, market string, owner string, openOrdersAddress string, orderID string, clientOrderID uint64) (*pb.GetOpenOrdersResponse, error)
+	GetUnsettledV2(ctx context.Context, market string, ownerAddress string) (*pb.GetUnsettledResponse, error)
+	PostOrderV2(ctx context.Context, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (*pb.PostOrderResponse, error)
 	SubmitOrderV2(ctx context.Context, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (string, error)
-	PostCancelOrderV2(ctx context.Context, request *api.PostCancelOrderRequestV2) (*api.PostCancelOrderResponseV2, error)
-	SubmitCancelOrderV2(ctx context.Context, request *api.PostCancelOrderRequestV2, skipPreFlight bool) (*api.PostSubmitBatchResponse, error)
-	PostSettleV2(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string) (*api.PostSettleResponse, error)
+	PostCancelOrderV2(ctx context.Context, request *pb.PostCancelOrderRequestV2) (*pb.PostCancelOrderResponseV2, error)
+	SubmitCancelOrderV2(ctx context.Context, request *pb.PostCancelOrderRequestV2, skipPreFlight bool) (*pb.PostSubmitBatchResponse, error)
+	PostSettleV2(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string) (*pb.PostSettleResponse, error)
 	SubmitSettleV2(ctx context.Context, owner, market, baseTokenWallet, quoteTokenWallet, openOrdersAccount string, skipPreflight bool) (string, error)
-	PostReplaceOrderV2(ctx context.Context, orderID, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (*api.PostOrderResponse, error)
+	PostReplaceOrderV2(ctx context.Context, orderID, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (*pb.PostOrderResponse, error)
 	SubmitReplaceOrderV2(ctx context.Context, orderID, owner, payer, market string, side string, orderType string, amount, price float64, opts PostOrderOpts) (string, error)
-	GetRecentBlockHash(ctx context.Context, request *api.GetRecentBlockHashRequest) (*api.GetRecentBlockHashResponse, error)
-	GetRecentBlockHashV2(ctx context.Context, request *api.GetRecentBlockHashRequestV2) (*api.GetRecentBlockHashResponseV2, error)
+	GetRecentBlockHash(ctx context.Context, request *pb.GetRecentBlockHashRequest) (*pb.GetRecentBlockHashResponse, error)
+	GetRecentBlockHashV2(ctx context.Context, request *pb.GetRecentBlockHashRequestV2) (*pb.GetRecentBlockHashResponseV2, error)
 }
 
 type WSClient struct {
-	api.UnimplementedApiServer
+	pb.UnimplementedApiServer
 
 	addr                 string
 	conn                 *connections.WS
@@ -241,8 +246,8 @@ func NewWSClientWithOpts(opts RPCOpts) (*WSClient, error) {
 		privateKey: opts.PrivateKey,
 	}
 	client.recentBlockHashStore = newRecentBlockHashStore(
-		func(ctx context.Context) (*api.GetRecentBlockHashResponse, error) {
-			return client.GetRecentBlockHash(ctx, &api.GetRecentBlockHashRequest{})
+		func(ctx context.Context) (*pb.GetRecentBlockHashResponse, error) {
+			return client.GetRecentBlockHash(ctx, &pb.GetRecentBlockHashRequest{})
 		},
 		client.GetRecentBlockHashStream,
 		opts,


### PR DESCRIPTION
gRPC Client:

- GetServerTime
- PostSubmitPaladinV2
- PostPumpFunSwapSol
- PostRaydiumCLMMRouteSwap
- PostRaydiumCLMMSwap

HTTP Client:

- GetServerTime
- PostSubmitPaladinV2
- PostPumpFunSwapSol
- GetRaydiumCPMMQuotes

WebSocket Client:

- GetServerTime
- PostSubmitPaladinV2
- PostPumpFunSwapSol
- GetRaydiumCPMMQuotes
- PostRaydiumCPMMSwap

Additionally I renamed the import in `providers/ws_interface.go` to `pb` to match convention.

I will revist adding examples for these endpoints when time permits.