### PR TITLE
Use protojson when marshalling HTTP requests

### DIFF
--- a/connections/http.go
+++ b/connections/http.go
@@ -3,7 +3,6 @@ package connections
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +10,7 @@ import (
 
 	package_info "github.com/bloXroute-Labs/solana-trader-client-go"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -50,12 +50,21 @@ func HTTPGetWithClient[T protoreflect.ProtoMessage](ctx context.Context, url str
 }
 
 func HTTPPostWithClient[T protoreflect.ProtoMessage](ctx context.Context, url string, client *http.Client, body interface{}, val T, authHeader string) error {
-	b, err := json.Marshal(body)
+	protoMsg := body.(proto.Message)
+
+	// Use protojson marshaler
+	marshaler := protojson.MarshalOptions{
+		UseProtoNames: true,
+	}
+	b, err := marshaler.Marshal(protoMsg)
 	if err != nil {
 		return err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Authorization", authHeader)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("x-sdk", package_info.Name)

--- a/provider/common.go
+++ b/provider/common.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/gagliardetto/solana-go"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
+	"github.com/bloXroute-Labs/solana-trader-client-go/utils"
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 )
 
@@ -175,7 +175,7 @@ func buildBatchRequest(transactions []*pb.TransactionMessage, privateKey solana.
 	}
 
 	batchRequest.UseBundle = &useBundle
-	batchRequest.Timestamp = timestamppb.New(time.Now())
+	batchRequest.Timestamp = utils.GetTimestamp()
 
 	return &batchRequest, nil
 }

--- a/provider/grpc.go
+++ b/provider/grpc.go
@@ -3,9 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
@@ -407,7 +404,7 @@ func (g *GRPCClient) PostSubmit(ctx context.Context, tx *pb.TransactionMessage, 
 		AllowBackRun:           &opts.AllowBackRun,
 		RevenueAddress:         &opts.RevenueAddress,
 		Sniping:                &opts.Sniping,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	})
 }
 
@@ -422,7 +419,7 @@ func (g *GRPCClient) PostSubmitV2(ctx context.Context, tx *pb.TransactionMessage
 		Transaction:            tx,
 		SkipPreFlight:          opts.SkipPreFlight,
 		FrontRunningProtection: &opts.FrontRunningProtection,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	})
 }
 

--- a/provider/http.go
+++ b/provider/http.go
@@ -3,9 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"strings"
-	"time"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
@@ -498,7 +496,7 @@ func (h *HTTPClient) PostSubmit(ctx context.Context, txBase64 string, opts PostS
 		AllowBackRun:           &opts.AllowBackRun,
 		RevenueAddress:         &opts.RevenueAddress,
 		Sniping:                &opts.Sniping,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	}
 
 	var response pb.PostSubmitResponse
@@ -543,7 +541,7 @@ func (h *HTTPClient) PostSubmitV2(ctx context.Context, txBase64 string, opts Pos
 		AllowBackRun:           &opts.AllowBackRun,
 		RevenueAddress:         &opts.RevenueAddress,
 		Sniping:                &opts.Sniping,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	}
 
 	var response pb.PostSubmitResponse

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	"github.com/bloXroute-Labs/solana-trader-client-go/transaction"
@@ -581,7 +578,7 @@ func (w *WSClient) PostSubmit(ctx context.Context, txBase64 string, opts PostSub
 		AllowBackRun:           &opts.AllowBackRun,
 		RevenueAddress:         &opts.RevenueAddress,
 		Sniping:                &opts.Sniping,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	}
 	var response pb.PostSubmitResponse
 	err := w.conn.Request(ctx, "PostSubmit", request, &response)
@@ -635,7 +632,7 @@ func (w *WSClient) PostSubmitV2(ctx context.Context, txBase64 string, opts PostS
 		AllowBackRun:           &opts.AllowBackRun,
 		RevenueAddress:         &opts.RevenueAddress,
 		Sniping:                &opts.Sniping,
-		Timestamp:              timestamppb.New(time.Now()),
+		Timestamp:              utils.GetTimestamp(),
 	}
 	var response pb.PostSubmitResponse
 	err = w.conn.Request(ctx, "PostSubmitV2", request, &response)

--- a/utils/timestamp.go
+++ b/utils/timestamp.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// GetTimestamp returns a Protocol Buffer Timestamp object based on the current time.
+func GetTimestamp() *timestamppb.Timestamp {
+	now := time.Now()
+	ts := timestamppb.New(now)
+	return ts
+}
+
+// GetRFC3339Timestamp returns the current time as an RFC 3339 formatted string suitable for
+// Protocol Buffer Timestamp JSON serialization.
+func GetRFC3339Timestamp() string {
+	now := time.Now().UTC()
+	formatted := now.Format(time.RFC3339Nano)
+	return formatted
+}


### PR DESCRIPTION
The current implementation of timestamps in the HTTP provider has a bug that causes the timestamp field to not be marshaled correctly in the HTTP POST request implementation. This corrects that issue.