### PR TITLE
Pump Swap AMM Swap Stream Examples

### DIFF
--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -359,6 +359,10 @@ var ExampleEndpoints = map[string]struct {
 		run:         callGetPumpFunNewAmmPoolGRPCStream,
 		description: "get new amm pools on pump swap",
 	},
+	"getPumpFunAmmSwapStream": {
+		run:         callGetPumpFunAmmSwapGRPCStream,
+		description: "get new amm swaps on pump swap",
+	},
 	"getBundleTipStream": {
 		run:         callGetBundleTipGRPCStream,
 		description: "get bundle tip stream",
@@ -2257,6 +2261,37 @@ func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
 	stream, err := gg.GetPumpFunNewAmmPoolStream(ctx, &pb.GetPumpFunNewAmmPoolStreamRequest{})
 	if err != nil {
 		log.Errorf("error with GetPumpFunNewAmmPool stream request: %v", err)
+		return true
+	}
+
+	ch := stream.Channel(0)
+	for i := 1; i <= 1; i++ {
+		v, ok := <-ch
+		if !ok {
+			return true
+		}
+		log.Infof("response %v received", v)
+	}
+	return false
+}
+
+func callGetPumpFunAmmSwapGRPCStream(g provider.GRPCClientTraderAPI) bool {
+	gg, err := provider.NewGRPCClientPumpNY()
+	if err != nil {
+		log.Errorf("failed to create pump provider: %v", err)
+		return true
+	}
+
+	log.Info("starting GetPumpFunAMMSwap stream")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := gg.GetPumpFunAmmSwapStream(ctx, &pb.GetPumpFunAMMSwapStreamRequest{
+		Pools: []string{"Gj5t6KjTw3gWW7SrMHEi1ojCkaYHyvLwb17gktf96HNH"},
+	})
+	if err != nil {
+		log.Errorf("error with GetPumpFunAMMSwap stream request: %v", err)
 		return true
 	}
 

--- a/examples/wsclient/main.go
+++ b/examples/wsclient/main.go
@@ -358,6 +358,10 @@ var ExampleEndpoints = map[string]struct {
 		run:         callGetPumpFunNewTokensWSStreamWrap,
 		description: "get pump fun new token stream",
 	},
+	"getPumpFunAmmSwapStream": {
+		run:         callGetPumpFunAmmSwapWSStream,
+		description: "get pump swap swaps stream",
+	},
 	"getPumpFunNewAmmPoolStream": {
 		run:         callGetPumpFunNewAmmPoolWSStream,
 		description: "get new amm pools on pump swap",
@@ -2273,6 +2277,36 @@ func callGetPumpFunNewTokensWSStream(w provider.WSClientTraderAPI) (string, bool
 		mint = v.Mint
 	}
 	return mint, false
+}
+
+func callGetPumpFunAmmSwapWSStream(_ provider.WSClientTraderAPI) bool {
+	log.Info("starting GetPumpFunAMMSwap stream")
+	wp, err := provider.NewWSClientPumpNY()
+	if err != nil {
+		log.Errorf("failed to create pump fun provider: %v", err)
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stream, err := wp.GetPumpFunAmmSwapStream(ctx, &pb.GetPumpFunAMMSwapStreamRequest{
+		Pools: []string{"Gj5t6KjTw3gWW7SrMHEi1ojCkaYHyvLwb17gktf96HNH"},
+	})
+	if err != nil {
+		log.Errorf("error with GetPumpFunAMMSwap stream request: %v", err)
+		return true
+	}
+
+	ch := stream.Channel(0)
+	for i := 1; i <= 1; i++ {
+		v, ok := <-ch
+		if !ok {
+			return true
+		}
+		log.Infof("response %v received", v)
+	}
+	return false
 }
 
 func callGetPumpFunNewAmmPoolWSStream(w provider.WSClientTraderAPI) bool {

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -144,6 +144,7 @@ type GRPCClientTraderAPI interface {
 	SubmitReplaceOrder(ctx context.Context, orderID, owner, payer, market string, side pb.Side, types []common.OrderType, amount, price float64, project pb.Project, opts PostOrderOpts) (string, error)
 	GetOrderbookStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error)
 	GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpFunSwapsStreamRequest) (connections.Streamer[*pb.GetPumpFunSwapsStreamResponse], error)
+	GetPumpFunAmmSwapStream(ctx context.Context, req *pb.GetPumpFunAMMSwapStreamRequest) (connections.Streamer[*pb.GetPumpFunAMMSwapStreamResponse], error)
 	GetPumpFunNewTokensStream(ctx context.Context, req *pb.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*pb.GetPumpFunNewTokensStreamResponse], error)
 	GetMarketDepthsStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetMarketDepthsStreamResponse], error)
 	GetTradesStream(ctx context.Context, market string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetTradesStreamResponse], error)

--- a/provider/ws.go
+++ b/provider/ws.go
@@ -1210,7 +1210,7 @@ func (w *WSClient) GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpFun
 
 // GetPumpFunAmmSwapStream subscribes to a stream for swap events related to a set of pumpdotswap tokens
 func (w *WSClient) GetPumpFunAmmSwapStream(ctx context.Context, req *pb.GetPumpFunAMMSwapStreamRequest) (connections.Streamer[*pb.GetPumpFunAMMSwapStreamResponse], error) {
-	return connections.WSStreamProto(w.conn, ctx, "GetPumpFunAmmSwapStream", req, func() *pb.GetPumpFunAMMSwapStreamResponse {
+	return connections.WSStreamProto(w.conn, ctx, "GetPumpFunAMMSwapStream", req, func() *pb.GetPumpFunAMMSwapStreamResponse {
 		var v pb.GetPumpFunAMMSwapStreamResponse
 		return &v
 	})

--- a/provider/ws_interfaces.go
+++ b/provider/ws_interfaces.go
@@ -134,6 +134,7 @@ type WSClientTraderAPI interface {
 	Close() error
 	GetOrderbooksStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetOrderbooksStreamResponse], error)
 	GetPumpFunSwapsStream(ctx context.Context, req *pb.GetPumpFunSwapsStreamRequest) (connections.Streamer[*pb.GetPumpFunSwapsStreamResponse], error)
+	GetPumpFunAmmSwapStream(ctx context.Context, req *pb.GetPumpFunAMMSwapStreamRequest) (connections.Streamer[*pb.GetPumpFunAMMSwapStreamResponse], error)
 	GetPumpFunNewTokensStream(ctx context.Context, req *pb.GetPumpFunNewTokensStreamRequest) (connections.Streamer[*pb.GetPumpFunNewTokensStreamResponse], error)
 	GetMarketDepthsStream(ctx context.Context, markets []string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetMarketDepthsStreamResponse], error)
 	GetTradesStream(ctx context.Context, market string, limit uint32, project pb.Project) (connections.Streamer[*pb.GetTradesStreamResponse], error)


### PR DESCRIPTION
**New Features**
- Added examples in `/examples` directory demonstrating how to use `gRPC` and `WebSocket` providers to stream new PumpSwap AMM swaps

**Bug Fixes**
- Fixed incorrect stream name in `ws.go`

**Cleanup**
- Added `GetPumpFunAMMSwapStream` method to interfaces