### PR TITLE
removed defaulting TLS in SDK

### DIFF
--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -866,7 +866,7 @@ func callGetPumpFunQuotes(g provider.GRPCClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmQuotes(_ provider.GRPCClientTraderAPI) bool {
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1897,7 +1897,7 @@ func callPostPumpFunSwapWrap(g provider.GRPCClientTraderAPI) bool {
 
 func callPostPumpFunSwap(ownerAddr string) bool {
 	log.Info("starting PostPumpFunSwap test")
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1933,7 +1933,7 @@ func callPostPumpFunSwap(ownerAddr string) bool {
 
 func callPostPumpFunAmmSwap(_ provider.GRPCClientTraderAPI) bool {
 	log.Info("starting PostPumpFunAmmSwap test")
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -2281,7 +2281,7 @@ func callJupiterRouteSwap(g provider.GRPCClientTraderAPI, ownerAddr string) bool
 }
 
 func callGetpumpFunNewTokenGRPCStreamWrap(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2317,7 +2317,7 @@ func callGetPumpFunNewTokensGRPCStream(g provider.GRPCClientTraderAPI) (string, 
 }
 
 func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump provider: %v", err)
 		return true
@@ -2346,7 +2346,7 @@ func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmSwapGRPCStream(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump provider: %v", err)
 		return true

--- a/examples/helpers.go
+++ b/examples/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetPumpFunNewTokenHelper() (*pb.GetPumpFunNewTokensStreamResponse, error) {
-	grpcClient, err := provider.NewGRPCClientPumpNY()
+	grpcClient, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/httpclient/main.go
+++ b/examples/httpclient/main.go
@@ -822,7 +822,11 @@ func callGetPumpFunQuotesHTTP(h provider.HTTPClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmQuotes(_ provider.HTTPClientTraderAPI) bool {
-	g := provider.NewHTTPClientPumpNY()
+	g, err := provider.NewHTTPClientPumpNY(provider.MainnetPumpNYHTTP)
+	if err != nil {
+		log.Errorf("failed to create pump fun provider: %v", err)
+		return true
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1608,7 +1612,11 @@ func callPostPumpFunSwap(h provider.HTTPClientTraderAPI, ownerAddr string) bool 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	h = provider.NewHTTPClientPumpNY()
+	h, err := provider.NewHTTPClientPumpNY(provider.MainnetPumpNYHTTP)
+	if err != nil {
+		log.Errorf("failed to create pump fun provider: %v", err)
+		return true
+	}
 
 	newToken, err := examples.GetPumpFunNewTokenHelper()
 	if err != nil {
@@ -1638,7 +1646,11 @@ func callPostPumpFunSwap(h provider.HTTPClientTraderAPI, ownerAddr string) bool 
 
 func callPostPumpFunAmmSwap(_ provider.HTTPClientTraderAPI) bool {
 	log.Info("starting PostPumpFunAmmSwap test")
-	h := provider.NewHTTPClientPumpNY()
+	h, err := provider.NewHTTPClientPumpNY(provider.MainnetPumpNYHTTP)
+	if err != nil {
+		log.Errorf("failed to create pump fun provider: %v", err)
+		return true
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/examples/wsclient/main.go
+++ b/examples/wsclient/main.go
@@ -908,7 +908,7 @@ func callGetPumpFunQuotes(w provider.WSClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmQuotes(_ provider.WSClientTraderAPI) bool {
-	w, err := provider.NewWSClientPumpNY()
+	w, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1889,7 +1889,7 @@ func callPostPumpFunSwap(w provider.WSClientTraderAPI, ownerAddr string) bool {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1922,7 +1922,7 @@ func callPostPumpFunSwap(w provider.WSClientTraderAPI, ownerAddr string) bool {
 
 func callPostPumpFunAmmSwap(_ provider.WSClientTraderAPI) bool {
 	log.Info("starting PostPumpFunAmmSwap test")
-	w, err := provider.NewWSClientPumpNY()
+	w, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -2311,7 +2311,7 @@ func callGetTickersWSStream(w provider.WSClientTraderAPI) bool {
 }
 
 func callGetPumpFunNewTokensWSStreamWrap(_ provider.WSClientTraderAPI) bool {
-	ww, err := provider.NewWSClientPumpNY()
+	ww, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -2351,7 +2351,7 @@ func callGetPumpFunNewTokensWSStream(w provider.WSClientTraderAPI) (string, bool
 
 func callGetPumpFunAmmSwapWSStream(_ provider.WSClientTraderAPI) bool {
 	log.Info("starting GetPumpFunAMMSwap stream")
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump fun provider: %v", err)
 		return true
@@ -2382,7 +2382,7 @@ func callGetPumpFunAmmSwapWSStream(_ provider.WSClientTraderAPI) bool {
 func callGetPumpFunNewAmmPoolWSStream(w provider.WSClientTraderAPI) bool {
 	log.Info("starting GetPumpFunNewAmmPool stream")
 
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump fun provider: %v", err)
 		return true

--- a/provider/common.go
+++ b/provider/common.go
@@ -14,90 +14,6 @@ import (
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 )
 
-const (
-	mainnetNY     = "ny.solana.dex.blxrbdn.com"
-	mainnetPumpNY = "pump-ny.solana.dex.blxrbdn.com"
-	mainnetUK     = "uk.solana.dex.blxrbdn.com"
-	// see https://docs.bloxroute.com/solana/trader-api/introduction/regions for all regions of traderAPI. There are
-	// some regions below that are only available for transaction submission related endpoints, not full API service.
-	mainnetFrankfurt = "germany.solana.dex.blxrbdn.com"
-	mainnetLA        = "la.solana.dex.blxrbdn.com"
-	mainnetAmsterdam = "amsterdam.solana.dex.blxrbdn.com"
-	mainnetTokyo     = "tokyo.solana.dex.blxrbdn.com"
-	testnet          = "solana.dex.bxrtest.com"
-	devnet           = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
-)
-
-// for information about submit only regions, see documentation: https://docs.bloxroute.com/solana/trader-api/introduction/regions
-
-var (
-	MainnetNYHTTP     = httpEndpoint(mainnetNY, true)
-	MainnetPumpNYHTTP = httpEndpoint(mainnetPumpNY, true)
-	MainnetUKHTTP     = httpEndpoint(mainnetUK, true)
-
-	// submit only http
-	MainnetFrankfurtHTTP = httpEndpoint(mainnetFrankfurt, true)
-	MainnetLAHTTP        = httpEndpoint(mainnetLA, true)
-	MainnetAmsterdamHTTP = httpEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoHTTP     = httpEndpoint(mainnetTokyo, true)
-
-	MainnetNYWS     = wsEndpoint(mainnetNY, true)
-	MainnetPumpNYWS = wsEndpoint(mainnetPumpNY, true)
-	MainnetUKWS     = wsEndpoint(mainnetUK, true)
-
-	// submit only ws
-	MainnetFrankfurtWS = wsEndpoint(mainnetFrankfurt, true)
-	MainnetLAWS        = wsEndpoint(mainnetLA, true)
-	MainnetAmsterdamWS = wsEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoWS     = wsEndpoint(mainnetTokyo, true)
-
-	MainnetNYGRPC     = grpcEndpoint(mainnetNY, true)
-	MainnetPumpNYGRPC = grpcEndpoint(mainnetPumpNY, true)
-	MainnetUKGRPC     = grpcEndpoint(mainnetUK, true)
-
-	// submit only grpc
-	MainnetFrankfurtGRPC = grpcEndpoint(mainnetFrankfurt, true)
-	MainnetLAGRPC        = grpcEndpoint(mainnetLA, true)
-	MainnetAmsterdamGRPC = grpcEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoGRPC     = grpcEndpoint(mainnetTokyo, true)
-
-	TestnetHTTP = httpEndpoint(testnet, true)
-	TestnetWS   = wsEndpoint(testnet, true)
-	TestnetGRPC = grpcEndpoint(testnet, true)
-
-	DevnetHTTP = httpEndpoint(devnet, false)
-	DevnetWS   = wsEndpoint(devnet, false)
-	DevnetGRPC = grpcEndpoint(devnet, false)
-
-	LocalHTTP = "http://localhost:9000"
-	LocalWS   = "ws://localhost:9000/ws"
-	LocalGRPC = "localhost:9000"
-)
-
-func httpEndpoint(baseUrl string, secure bool) string {
-	prefix := "http"
-	if secure {
-		prefix = "https"
-	}
-	return fmt.Sprintf("%v://%v", prefix, baseUrl)
-}
-
-func wsEndpoint(baseUrl string, secure bool) string {
-	prefix := "ws"
-	if secure {
-		prefix = "wss"
-	}
-	return fmt.Sprintf("%v://%v/ws", prefix, baseUrl)
-}
-
-func grpcEndpoint(baseUrl string, secure bool) string {
-	port := "80"
-	if secure {
-		port = "443"
-	}
-	return fmt.Sprintf("%v:%v", baseUrl, port)
-}
-
 var ErrPrivateKeyNotFound = errors.New("private key not provided for signing transaction")
 
 type PostOrderOpts struct {
@@ -197,4 +113,13 @@ func createBatchRequestEntry(opts SubmitOpts, txBase64 string, privateKey solana
 	}
 
 	return &oneRequest, nil
+}
+
+func contains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
 }

--- a/provider/endpoints.go
+++ b/provider/endpoints.go
@@ -1,0 +1,317 @@
+package provider
+
+import (
+	"fmt"
+)
+
+// Warning to display when creating TLS client
+const WarningTLSSlowDown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
+
+// Endpoint type as before
+type Endpoint string
+
+// Region DNS struct
+type Region struct {
+	HTTP, HTTPSecure         string
+	WS, WSSecure             string
+	GRPC, GRPCSecure         string
+	PumpHTTP, PumpHTTPSecure string
+	PumpWS, PumpWSSecure     string
+	PumpGRPC, PumpGRPCSecure string
+}
+
+// Remote endpoints
+const (
+	NY         Endpoint = "ny.solana.dex.blxrbdn.com"
+	NYPump     Endpoint = "pump-ny.solana.dex.blxrbdn.com"
+	UK         Endpoint = "uk.solana.dex.blxrbdn.com"
+	UKPump     Endpoint = "pump-uk.solana.dex.blxrbdn.com"
+	Frankfurt  Endpoint = "germany.solana.dex.blxrbdn.com"
+	LosAngeles Endpoint = "la.solana.dex.blxrbdn.com"
+	Amsterdam  Endpoint = "amsterdam.solana.dex.blxrbdn.com"
+	Tokyo      Endpoint = "tokyo.solana.dex.blxrbdn.com"
+)
+
+// Developer endpoints
+const (
+	Testnet Endpoint = "solana.dex.bxrtest.com"
+	Devnet  Endpoint = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
+)
+
+// Local endpoints
+const (
+	LocalHTTP string = "http://localhost:9000"
+	LocalWS   string = "ws://localhost:9000/ws"
+	LocalGRPC string = "localhost:9000"
+)
+
+var endpointsByRegion = map[string]Region{
+	"NY": {
+		HTTP:       httpEndpoint(NY, false),
+		HTTPSecure: httpEndpoint(NY, true),
+		WS:         wsEndpoint(NY, false),
+		WSSecure:   wsEndpoint(NY, true),
+		GRPC:       grpcEndpoint(NY, false),
+		GRPCSecure: grpcEndpoint(NY, true),
+
+		PumpHTTP:       httpEndpoint(NYPump, false),
+		PumpHTTPSecure: httpEndpoint(NYPump, true),
+		PumpWS:         wsEndpoint(NYPump, false),
+		PumpWSSecure:   wsEndpoint(NYPump, true),
+		PumpGRPC:       grpcEndpoint(NYPump, false),
+		PumpGRPCSecure: grpcEndpoint(NYPump, true),
+	},
+	"UK": {
+		HTTP:       httpEndpoint(UK, false),
+		HTTPSecure: httpEndpoint(UK, true),
+		WS:         wsEndpoint(UK, false),
+		WSSecure:   wsEndpoint(UK, true),
+		GRPC:       grpcEndpoint(UK, false),
+		GRPCSecure: grpcEndpoint(UK, true),
+
+		PumpHTTP:       httpEndpoint(UKPump, false),
+		PumpHTTPSecure: httpEndpoint(UKPump, true),
+		PumpWS:         wsEndpoint(UKPump, false),
+		PumpWSSecure:   wsEndpoint(UKPump, true),
+		PumpGRPC:       grpcEndpoint(UKPump, false),
+		PumpGRPCSecure: grpcEndpoint(UKPump, true),
+	},
+	"Frankfurt": {
+		HTTP:       httpEndpoint(Frankfurt, false),
+		HTTPSecure: httpEndpoint(Frankfurt, true),
+		WS:         wsEndpoint(Frankfurt, false),
+		WSSecure:   wsEndpoint(Frankfurt, true),
+		GRPC:       grpcEndpoint(Frankfurt, false),
+		GRPCSecure: grpcEndpoint(Frankfurt, true),
+	},
+	"LosAngeles": {
+		HTTP:       httpEndpoint(LosAngeles, false),
+		HTTPSecure: httpEndpoint(LosAngeles, true),
+		WS:         wsEndpoint(LosAngeles, false),
+		WSSecure:   wsEndpoint(LosAngeles, true),
+		GRPC:       grpcEndpoint(LosAngeles, false),
+		GRPCSecure: grpcEndpoint(LosAngeles, true),
+	},
+	"Amsterdam": {
+		HTTP:       httpEndpoint(Amsterdam, false),
+		HTTPSecure: httpEndpoint(Amsterdam, true),
+		WS:         wsEndpoint(Amsterdam, false),
+		WSSecure:   wsEndpoint(Amsterdam, true),
+		GRPC:       grpcEndpoint(Amsterdam, false),
+		GRPCSecure: grpcEndpoint(Amsterdam, true),
+	},
+	"Tokyo": {
+		HTTP:       httpEndpoint(Tokyo, false),
+		HTTPSecure: httpEndpoint(Tokyo, true),
+		WS:         wsEndpoint(Tokyo, false),
+		WSSecure:   wsEndpoint(Tokyo, true),
+		GRPC:       grpcEndpoint(Tokyo, false),
+		GRPCSecure: grpcEndpoint(Tokyo, true),
+	},
+	"Testnet": {
+		HTTP:       httpEndpoint(Testnet, false),
+		HTTPSecure: httpEndpoint(Testnet, true),
+		WS:         wsEndpoint(Testnet, false),
+		WSSecure:   wsEndpoint(Testnet, true),
+		GRPC:       grpcEndpoint(Testnet, false),
+		GRPCSecure: grpcEndpoint(Testnet, true),
+	},
+	"Devnet": {
+		HTTP:       httpEndpoint(Devnet, false),
+		HTTPSecure: httpEndpoint(Devnet, true),
+		WS:         wsEndpoint(Devnet, false),
+		WSSecure:   wsEndpoint(Devnet, true),
+		GRPC:       grpcEndpoint(Devnet, false),
+		GRPCSecure: grpcEndpoint(Devnet, true),
+	},
+}
+
+var (
+	MainnetNYHTTP       = endpointsByRegion["NY"].HTTP
+	MainnetNYHTTPSecure = endpointsByRegion["NY"].HTTPSecure
+	MainnetNYWS         = endpointsByRegion["NY"].WS
+	MainnetNYWSSecure   = endpointsByRegion["NY"].WSSecure
+	MainnetNYGRPC       = endpointsByRegion["NY"].GRPC
+	MainnetNYGRPCSecure = endpointsByRegion["NY"].GRPCSecure
+
+	MainnetPumpNYHTTP       = endpointsByRegion["NY"].PumpHTTP
+	MainnetPumpNYHTTPSecure = endpointsByRegion["NY"].PumpHTTPSecure
+	MainnetPumpNYWS         = endpointsByRegion["NY"].PumpWS
+	MainnetPumpNYWSSecure   = endpointsByRegion["NY"].PumpWSSecure
+	MainnetPumpNYGRPC       = endpointsByRegion["NY"].PumpGRPC
+	MainnetPumpNYGRPCSecure = endpointsByRegion["NY"].PumpGRPCSecure
+
+	MainnetUKHTTP       = endpointsByRegion["UK"].HTTP
+	MainnetUKHTTPSecure = endpointsByRegion["UK"].HTTPSecure
+	MainnetUKWS         = endpointsByRegion["UK"].WS
+	MainnetUKWSSecure   = endpointsByRegion["UK"].WSSecure
+	MainnetUKGRPC       = endpointsByRegion["UK"].GRPC
+	MainnetUKGRPCSecure = endpointsByRegion["UK"].GRPCSecure
+
+	MainnetPumpUKHTTP       = endpointsByRegion["UK"].PumpHTTP
+	MainnetPumpUKHTTPSecure = endpointsByRegion["UK"].PumpHTTPSecure
+	MainnetPumpUKWS         = endpointsByRegion["UK"].PumpWS
+	MainnetPumpUKWSSecure   = endpointsByRegion["UK"].PumpWSSecure
+	MainnetPumpUKGRPC       = endpointsByRegion["UK"].PumpGRPC
+	MainnetPumpUKGRPCSecure = endpointsByRegion["UK"].PumpGRPCSecure
+
+	MainnetFrankfurtHTTP       = endpointsByRegion["Frankfurt"].HTTP
+	MainnetFrankfurtHTTPSecure = endpointsByRegion["Frankfurt"].HTTPSecure
+	MainnetFrankfurtWS         = endpointsByRegion["Frankfurt"].WS
+	MainnetFrankfurtWSSecure   = endpointsByRegion["Frankfurt"].WSSecure
+	MainnetFrankfurtGRPC       = endpointsByRegion["Frankfurt"].GRPC
+	MainnetFrankfurtGRPCSecure = endpointsByRegion["Frankfurt"].GRPCSecure
+
+	MainnetLAHTTP       = endpointsByRegion["LosAngeles"].HTTP
+	MainnetLAHTTPSecure = endpointsByRegion["LosAngeles"].HTTPSecure
+	MainnetLAWS         = endpointsByRegion["LosAngeles"].WS
+	MainnetLAWSSecure   = endpointsByRegion["LosAngeles"].WSSecure
+	MainnetLAGRPC       = endpointsByRegion["LosAngeles"].GRPC
+	MainnetLAGRPCSecure = endpointsByRegion["LosAngeles"].GRPCSecure
+
+	MainnetAmsterdamHTTP       = endpointsByRegion["Amsterdam"].HTTP
+	MainnetAmsterdamHTTPSecure = endpointsByRegion["Amsterdam"].HTTPSecure
+	MainnetAmsterdamWS         = endpointsByRegion["Amsterdam"].WS
+	MainnetAmsterdamWSSecure   = endpointsByRegion["Amsterdam"].WSSecure
+	MainnetAmsterdamGRPC       = endpointsByRegion["Amsterdam"].GRPC
+	MainnetAmsterdamGRPCSecure = endpointsByRegion["Amsterdam"].GRPCSecure
+
+	MainnetTokyoHTTP       = endpointsByRegion["Tokyo"].HTTP
+	MainnetTokyoHTTPSecure = endpointsByRegion["Tokyo"].HTTPSecure
+	MainnetTokyoWS         = endpointsByRegion["Tokyo"].WS
+	MainnetTokyoWSSecure   = endpointsByRegion["Tokyo"].WSSecure
+	MainnetTokyoGRPC       = endpointsByRegion["Tokyo"].GRPC
+	MainnetTokyoGRPCSecure = endpointsByRegion["Tokyo"].GRPCSecure
+
+	TestnetHTTP       = endpointsByRegion["Testnet"].HTTP
+	TestnetHTTPSecure = endpointsByRegion["Testnet"].HTTPSecure
+	TestnetWS         = endpointsByRegion["Testnet"].WS
+	TestnetWSSecure   = endpointsByRegion["Testnet"].WSSecure
+	TestnetGRPC       = endpointsByRegion["Testnet"].GRPC
+	TestnetGRPCSecure = endpointsByRegion["Testnet"].GRPCSecure
+
+	DevnetHTTP       = endpointsByRegion["Devnet"].HTTP
+	DevnetHTTPSecure = endpointsByRegion["Devnet"].HTTPSecure
+	DevnetWS         = endpointsByRegion["Devnet"].WS
+	DevnetWSSecure   = endpointsByRegion["Devnet"].WSSecure
+	DevnetGRPC       = endpointsByRegion["Devnet"].GRPC
+	DevnetGRPCSecure = endpointsByRegion["Devnet"].GRPCSecure
+)
+
+func GetFullServiceGRPCAllEndpoints() []string {
+	return []string{
+		MainnetNYGRPC,
+		MainnetNYGRPCSecure,
+		MainnetUKGRPC,
+		MainnetUKGRPCSecure,
+	}
+}
+
+func GetFullServiceHTTPAllEndpoints() []string {
+	return []string{
+		MainnetNYHTTP,
+		MainnetNYHTTPSecure,
+		MainnetUKHTTP,
+		MainnetUKHTTPSecure,
+	}
+}
+
+func GetFullServiceWSAllEndpoints() []string {
+	return []string{
+		MainnetNYWS,
+		MainnetNYWSSecure,
+		MainnetUKWS,
+		MainnetUKWSSecure,
+	}
+}
+
+func GetSubmitOnlyGRPCAllEndpoints() []string {
+	return []string{
+		MainnetAmsterdamGRPC,
+		MainnetAmsterdamGRPCSecure,
+		MainnetLAGRPC,
+		MainnetLAGRPCSecure,
+		MainnetFrankfurtGRPC,
+		MainnetFrankfurtGRPCSecure,
+		MainnetTokyoGRPC,
+		MainnetTokyoGRPCSecure,
+	}
+}
+
+func GetSubmitOnlyHTTPAllEndpoints() []string {
+	return []string{
+		MainnetAmsterdamHTTP,
+		MainnetAmsterdamHTTPSecure,
+		MainnetLAHTTP,
+		MainnetLAHTTPSecure,
+		MainnetFrankfurtHTTP,
+		MainnetFrankfurtHTTPSecure,
+		MainnetTokyoHTTP,
+		MainnetTokyoHTTPSecure,
+	}
+}
+
+func GetSubmitOnlyWSAllEndpoints() []string {
+	return []string{
+		MainnetAmsterdamWS,
+		MainnetAmsterdamWSSecure,
+		MainnetLAWS,
+		MainnetLAWSSecure,
+		MainnetFrankfurtWS,
+		MainnetFrankfurtWSSecure,
+		MainnetTokyoWS,
+		MainnetTokyoWSSecure,
+	}
+}
+
+func GetPumpGRPCAllEndpoints() []string {
+	return []string{
+		MainnetPumpNYGRPC,
+		MainnetPumpNYGRPCSecure,
+		MainnetPumpUKGRPC,
+		MainnetPumpUKGRPCSecure,
+	}
+}
+
+func GetPumpHTTPAllEndpoints() []string {
+	return []string{
+		MainnetPumpNYHTTP,
+		MainnetPumpNYHTTPSecure,
+		MainnetPumpUKHTTP,
+		MainnetPumpUKHTTPSecure,
+	}
+}
+
+func GetPumpWSAllEndpoints() []string {
+	return []string{
+		MainnetPumpNYWS,
+		MainnetPumpNYWSSecure,
+		MainnetPumpUKWS,
+		MainnetPumpUKWSSecure,
+	}
+}
+
+// Endpoint string generators
+func httpEndpoint(e Endpoint, secure bool) string {
+	proto := "http"
+	if secure {
+		proto = "https"
+	}
+	return fmt.Sprintf("%s://%s", proto, e)
+}
+
+func wsEndpoint(e Endpoint, secure bool) string {
+	proto := "ws"
+	if secure {
+		proto = "wss"
+	}
+	return fmt.Sprintf("%s://%s/ws", proto, e)
+}
+
+func grpcEndpoint(e Endpoint, secure bool) string {
+	port := "80"
+	if secure {
+		port = "443"
+	}
+	return fmt.Sprintf("%s:%s", e, port)
+}

--- a/provider/endpoints.go
+++ b/provider/endpoints.go
@@ -7,10 +7,29 @@ import (
 // Warning to display when creating TLS client
 const WarningTLSSlowDown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
 
-// Endpoint type as before
-type Endpoint string
+type Protocol string
 
-// Region DNS struct
+const (
+	HTTP Protocol = "http"
+	WS   Protocol = "ws"
+	GRPC Protocol = "grpc"
+)
+
+type ServiceType string
+
+const (
+	FullService ServiceType = "full"
+	SubmitOnly  ServiceType = "submit"
+	Pump        ServiceType = "pump"
+	Development ServiceType = "dev"
+)
+
+type EndpointConfig struct {
+	Host        string
+	ServiceType ServiceType
+	PumpHost    string
+}
+
 type Region struct {
 	HTTP, HTTPSecure         string
 	WS, WSSecure             string
@@ -20,23 +39,43 @@ type Region struct {
 	PumpGRPC, PumpGRPCSecure string
 }
 
-// Remote endpoints
-const (
-	NY         Endpoint = "ny.solana.dex.blxrbdn.com"
-	NYPump     Endpoint = "pump-ny.solana.dex.blxrbdn.com"
-	UK         Endpoint = "uk.solana.dex.blxrbdn.com"
-	UKPump     Endpoint = "pump-uk.solana.dex.blxrbdn.com"
-	Frankfurt  Endpoint = "germany.solana.dex.blxrbdn.com"
-	LosAngeles Endpoint = "la.solana.dex.blxrbdn.com"
-	Amsterdam  Endpoint = "amsterdam.solana.dex.blxrbdn.com"
-	Tokyo      Endpoint = "tokyo.solana.dex.blxrbdn.com"
-)
-
-// Developer endpoints
-const (
-	Testnet Endpoint = "solana.dex.bxrtest.com"
-	Devnet  Endpoint = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
-)
+// Regional endpoint configurations
+var endpointConfigs = map[string]EndpointConfig{
+	"NY": {
+		Host:        "ny.solana.dex.blxrbdn.com",
+		ServiceType: FullService,
+		PumpHost:    "pump-ny.solana.dex.blxrbdn.com",
+	},
+	"UK": {
+		Host:        "uk.solana.dex.blxrbdn.com",
+		ServiceType: FullService,
+		PumpHost:    "pump-uk.solana.dex.blxrbdn.com",
+	},
+	"Frankfurt": {
+		Host:        "germany.solana.dex.blxrbdn.com",
+		ServiceType: SubmitOnly,
+	},
+	"LosAngeles": {
+		Host:        "la.solana.dex.blxrbdn.com",
+		ServiceType: SubmitOnly,
+	},
+	"Amsterdam": {
+		Host:        "amsterdam.solana.dex.blxrbdn.com",
+		ServiceType: SubmitOnly,
+	},
+	"Tokyo": {
+		Host:        "tokyo.solana.dex.blxrbdn.com",
+		ServiceType: SubmitOnly,
+	},
+	"Testnet": {
+		Host:        "solana.dex.bxrtest.com",
+		ServiceType: Development,
+	},
+	"Devnet": {
+		Host:        "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com",
+		ServiceType: Development,
+	},
+}
 
 // Local endpoints
 const (
@@ -45,273 +84,187 @@ const (
 	LocalGRPC string = "localhost:9000"
 )
 
-var endpointsByRegion = map[string]Region{
-	"NY": {
-		HTTP:       httpEndpoint(NY, false),
-		HTTPSecure: httpEndpoint(NY, true),
-		WS:         wsEndpoint(NY, false),
-		WSSecure:   wsEndpoint(NY, true),
-		GRPC:       grpcEndpoint(NY, false),
-		GRPCSecure: grpcEndpoint(NY, true),
-
-		PumpHTTP:       httpEndpoint(NYPump, false),
-		PumpHTTPSecure: httpEndpoint(NYPump, true),
-		PumpWS:         wsEndpoint(NYPump, false),
-		PumpWSSecure:   wsEndpoint(NYPump, true),
-		PumpGRPC:       grpcEndpoint(NYPump, false),
-		PumpGRPCSecure: grpcEndpoint(NYPump, true),
-	},
-	"UK": {
-		HTTP:       httpEndpoint(UK, false),
-		HTTPSecure: httpEndpoint(UK, true),
-		WS:         wsEndpoint(UK, false),
-		WSSecure:   wsEndpoint(UK, true),
-		GRPC:       grpcEndpoint(UK, false),
-		GRPCSecure: grpcEndpoint(UK, true),
-
-		PumpHTTP:       httpEndpoint(UKPump, false),
-		PumpHTTPSecure: httpEndpoint(UKPump, true),
-		PumpWS:         wsEndpoint(UKPump, false),
-		PumpWSSecure:   wsEndpoint(UKPump, true),
-		PumpGRPC:       grpcEndpoint(UKPump, false),
-		PumpGRPCSecure: grpcEndpoint(UKPump, true),
-	},
-	"Frankfurt": {
-		HTTP:       httpEndpoint(Frankfurt, false),
-		HTTPSecure: httpEndpoint(Frankfurt, true),
-		WS:         wsEndpoint(Frankfurt, false),
-		WSSecure:   wsEndpoint(Frankfurt, true),
-		GRPC:       grpcEndpoint(Frankfurt, false),
-		GRPCSecure: grpcEndpoint(Frankfurt, true),
-	},
-	"LosAngeles": {
-		HTTP:       httpEndpoint(LosAngeles, false),
-		HTTPSecure: httpEndpoint(LosAngeles, true),
-		WS:         wsEndpoint(LosAngeles, false),
-		WSSecure:   wsEndpoint(LosAngeles, true),
-		GRPC:       grpcEndpoint(LosAngeles, false),
-		GRPCSecure: grpcEndpoint(LosAngeles, true),
-	},
-	"Amsterdam": {
-		HTTP:       httpEndpoint(Amsterdam, false),
-		HTTPSecure: httpEndpoint(Amsterdam, true),
-		WS:         wsEndpoint(Amsterdam, false),
-		WSSecure:   wsEndpoint(Amsterdam, true),
-		GRPC:       grpcEndpoint(Amsterdam, false),
-		GRPCSecure: grpcEndpoint(Amsterdam, true),
-	},
-	"Tokyo": {
-		HTTP:       httpEndpoint(Tokyo, false),
-		HTTPSecure: httpEndpoint(Tokyo, true),
-		WS:         wsEndpoint(Tokyo, false),
-		WSSecure:   wsEndpoint(Tokyo, true),
-		GRPC:       grpcEndpoint(Tokyo, false),
-		GRPCSecure: grpcEndpoint(Tokyo, true),
-	},
-	"Testnet": {
-		HTTP:       httpEndpoint(Testnet, false),
-		HTTPSecure: httpEndpoint(Testnet, true),
-		WS:         wsEndpoint(Testnet, false),
-		WSSecure:   wsEndpoint(Testnet, true),
-		GRPC:       grpcEndpoint(Testnet, false),
-		GRPCSecure: grpcEndpoint(Testnet, true),
-	},
-	"Devnet": {
-		HTTP:       httpEndpoint(Devnet, false),
-		HTTPSecure: httpEndpoint(Devnet, true),
-		WS:         wsEndpoint(Devnet, false),
-		WSSecure:   wsEndpoint(Devnet, true),
-		GRPC:       grpcEndpoint(Devnet, false),
-		GRPCSecure: grpcEndpoint(Devnet, true),
-	},
-}
+var endpointsByRegion = generateRegions()
 
 var (
-	MainnetNYHTTP       = endpointsByRegion["NY"].HTTP
-	MainnetNYHTTPSecure = endpointsByRegion["NY"].HTTPSecure
-	MainnetNYWS         = endpointsByRegion["NY"].WS
-	MainnetNYWSSecure   = endpointsByRegion["NY"].WSSecure
-	MainnetNYGRPC       = endpointsByRegion["NY"].GRPC
-	MainnetNYGRPCSecure = endpointsByRegion["NY"].GRPCSecure
+	// NY Endpoints
+	MainnetNYHTTP, MainnetNYHTTPSecure         = getEndpoints("NY", HTTP)
+	MainnetNYWS, MainnetNYWSSecure             = getEndpoints("NY", WS)
+	MainnetNYGRPC, MainnetNYGRPCSecure         = getEndpoints("NY", GRPC)
+	MainnetPumpNYHTTP, MainnetPumpNYHTTPSecure = getPumpEndpoints("NY", HTTP)
+	MainnetPumpNYWS, MainnetPumpNYWSSecure     = getPumpEndpoints("NY", WS)
+	MainnetPumpNYGRPC, MainnetPumpNYGRPCSecure = getPumpEndpoints("NY", GRPC)
 
-	MainnetPumpNYHTTP       = endpointsByRegion["NY"].PumpHTTP
-	MainnetPumpNYHTTPSecure = endpointsByRegion["NY"].PumpHTTPSecure
-	MainnetPumpNYWS         = endpointsByRegion["NY"].PumpWS
-	MainnetPumpNYWSSecure   = endpointsByRegion["NY"].PumpWSSecure
-	MainnetPumpNYGRPC       = endpointsByRegion["NY"].PumpGRPC
-	MainnetPumpNYGRPCSecure = endpointsByRegion["NY"].PumpGRPCSecure
+	// UK Endpoints
+	MainnetUKHTTP, MainnetUKHTTPSecure         = getEndpoints("UK", HTTP)
+	MainnetUKWS, MainnetUKWSSecure             = getEndpoints("UK", WS)
+	MainnetUKGRPC, MainnetUKGRPCSecure         = getEndpoints("UK", GRPC)
+	MainnetPumpUKHTTP, MainnetPumpUKHTTPSecure = getPumpEndpoints("UK", HTTP)
+	MainnetPumpUKWS, MainnetPumpUKWSSecure     = getPumpEndpoints("UK", WS)
+	MainnetPumpUKGRPC, MainnetPumpUKGRPCSecure = getPumpEndpoints("UK", GRPC)
 
-	MainnetUKHTTP       = endpointsByRegion["UK"].HTTP
-	MainnetUKHTTPSecure = endpointsByRegion["UK"].HTTPSecure
-	MainnetUKWS         = endpointsByRegion["UK"].WS
-	MainnetUKWSSecure   = endpointsByRegion["UK"].WSSecure
-	MainnetUKGRPC       = endpointsByRegion["UK"].GRPC
-	MainnetUKGRPCSecure = endpointsByRegion["UK"].GRPCSecure
+	// Other regions (Submit-only)
+	MainnetFrankfurtHTTP, MainnetFrankfurtHTTPSecure = getEndpoints("Frankfurt", HTTP)
+	MainnetFrankfurtWS, MainnetFrankfurtWSSecure     = getEndpoints("Frankfurt", WS)
+	MainnetFrankfurtGRPC, MainnetFrankfurtGRPCSecure = getEndpoints("Frankfurt", GRPC)
+	MainnetLAHTTP, MainnetLAHTTPSecure               = getEndpoints("LosAngeles", HTTP)
+	MainnetLAWS, MainnetLAWSSecure                   = getEndpoints("LosAngeles", WS)
+	MainnetLAGRPC, MainnetLAGRPCSecure               = getEndpoints("LosAngeles", GRPC)
+	MainnetAmsterdamHTTP, MainnetAmsterdamHTTPSecure = getEndpoints("Amsterdam", HTTP)
+	MainnetAmsterdamWS, MainnetAmsterdamWSSecure     = getEndpoints("Amsterdam", WS)
+	MainnetAmsterdamGRPC, MainnetAmsterdamGRPCSecure = getEndpoints("Amsterdam", GRPC)
+	MainnetTokyoHTTP, MainnetTokyoHTTPSecure         = getEndpoints("Tokyo", HTTP)
+	MainnetTokyoWS, MainnetTokyoWSSecure             = getEndpoints("Tokyo", WS)
+	MainnetTokyoGRPC, MainnetTokyoGRPCSecure         = getEndpoints("Tokyo", GRPC)
 
-	MainnetPumpUKHTTP       = endpointsByRegion["UK"].PumpHTTP
-	MainnetPumpUKHTTPSecure = endpointsByRegion["UK"].PumpHTTPSecure
-	MainnetPumpUKWS         = endpointsByRegion["UK"].PumpWS
-	MainnetPumpUKWSSecure   = endpointsByRegion["UK"].PumpWSSecure
-	MainnetPumpUKGRPC       = endpointsByRegion["UK"].PumpGRPC
-	MainnetPumpUKGRPCSecure = endpointsByRegion["UK"].PumpGRPCSecure
-
-	MainnetFrankfurtHTTP       = endpointsByRegion["Frankfurt"].HTTP
-	MainnetFrankfurtHTTPSecure = endpointsByRegion["Frankfurt"].HTTPSecure
-	MainnetFrankfurtWS         = endpointsByRegion["Frankfurt"].WS
-	MainnetFrankfurtWSSecure   = endpointsByRegion["Frankfurt"].WSSecure
-	MainnetFrankfurtGRPC       = endpointsByRegion["Frankfurt"].GRPC
-	MainnetFrankfurtGRPCSecure = endpointsByRegion["Frankfurt"].GRPCSecure
-
-	MainnetLAHTTP       = endpointsByRegion["LosAngeles"].HTTP
-	MainnetLAHTTPSecure = endpointsByRegion["LosAngeles"].HTTPSecure
-	MainnetLAWS         = endpointsByRegion["LosAngeles"].WS
-	MainnetLAWSSecure   = endpointsByRegion["LosAngeles"].WSSecure
-	MainnetLAGRPC       = endpointsByRegion["LosAngeles"].GRPC
-	MainnetLAGRPCSecure = endpointsByRegion["LosAngeles"].GRPCSecure
-
-	MainnetAmsterdamHTTP       = endpointsByRegion["Amsterdam"].HTTP
-	MainnetAmsterdamHTTPSecure = endpointsByRegion["Amsterdam"].HTTPSecure
-	MainnetAmsterdamWS         = endpointsByRegion["Amsterdam"].WS
-	MainnetAmsterdamWSSecure   = endpointsByRegion["Amsterdam"].WSSecure
-	MainnetAmsterdamGRPC       = endpointsByRegion["Amsterdam"].GRPC
-	MainnetAmsterdamGRPCSecure = endpointsByRegion["Amsterdam"].GRPCSecure
-
-	MainnetTokyoHTTP       = endpointsByRegion["Tokyo"].HTTP
-	MainnetTokyoHTTPSecure = endpointsByRegion["Tokyo"].HTTPSecure
-	MainnetTokyoWS         = endpointsByRegion["Tokyo"].WS
-	MainnetTokyoWSSecure   = endpointsByRegion["Tokyo"].WSSecure
-	MainnetTokyoGRPC       = endpointsByRegion["Tokyo"].GRPC
-	MainnetTokyoGRPCSecure = endpointsByRegion["Tokyo"].GRPCSecure
-
-	TestnetHTTP       = endpointsByRegion["Testnet"].HTTP
-	TestnetHTTPSecure = endpointsByRegion["Testnet"].HTTPSecure
-	TestnetWS         = endpointsByRegion["Testnet"].WS
-	TestnetWSSecure   = endpointsByRegion["Testnet"].WSSecure
-	TestnetGRPC       = endpointsByRegion["Testnet"].GRPC
-	TestnetGRPCSecure = endpointsByRegion["Testnet"].GRPCSecure
-
-	DevnetHTTP       = endpointsByRegion["Devnet"].HTTP
-	DevnetHTTPSecure = endpointsByRegion["Devnet"].HTTPSecure
-	DevnetWS         = endpointsByRegion["Devnet"].WS
-	DevnetWSSecure   = endpointsByRegion["Devnet"].WSSecure
-	DevnetGRPC       = endpointsByRegion["Devnet"].GRPC
-	DevnetGRPCSecure = endpointsByRegion["Devnet"].GRPCSecure
+	// Development endpoints
+	TestnetHTTP, TestnetHTTPSecure = getEndpoints("Testnet", HTTP)
+	TestnetWS, TestnetWSSecure     = getEndpoints("Testnet", WS)
+	TestnetGRPC, TestnetGRPCSecure = getEndpoints("Testnet", GRPC)
+	DevnetHTTP, DevnetHTTPSecure   = getEndpoints("Devnet", HTTP)
+	DevnetWS, DevnetWSSecure       = getEndpoints("Devnet", WS)
+	DevnetGRPC, DevnetGRPCSecure   = getEndpoints("Devnet", GRPC)
 )
 
-func GetFullServiceGRPCAllEndpoints() []string {
-	return []string{
-		MainnetNYGRPC,
-		MainnetNYGRPCSecure,
-		MainnetUKGRPC,
-		MainnetUKGRPCSecure,
+func generateRegions() map[string]Region {
+	regions := make(map[string]Region)
+
+	for name, config := range endpointConfigs {
+		region := Region{
+			HTTP:       buildEndpoint(config.Host, HTTP, false),
+			HTTPSecure: buildEndpoint(config.Host, HTTP, true),
+			WS:         buildEndpoint(config.Host, WS, false),
+			WSSecure:   buildEndpoint(config.Host, WS, true),
+			GRPC:       buildEndpoint(config.Host, GRPC, false),
+			GRPCSecure: buildEndpoint(config.Host, GRPC, true),
+		}
+
+		// Add pump endpoints if available
+		if config.PumpHost != "" {
+			region.PumpHTTP = buildEndpoint(config.PumpHost, HTTP, false)
+			region.PumpHTTPSecure = buildEndpoint(config.PumpHost, HTTP, true)
+			region.PumpWS = buildEndpoint(config.PumpHost, WS, false)
+			region.PumpWSSecure = buildEndpoint(config.PumpHost, WS, true)
+			region.PumpGRPC = buildEndpoint(config.PumpHost, GRPC, false)
+			region.PumpGRPCSecure = buildEndpoint(config.PumpHost, GRPC, true)
+		}
+
+		regions[name] = region
 	}
+
+	return regions
+}
+
+func buildEndpoint(host string, protocol Protocol, secure bool) string {
+	switch protocol {
+	case HTTP:
+		scheme := "http"
+		if secure {
+			scheme = "https"
+		}
+		return fmt.Sprintf("%s://%s", scheme, host)
+	case WS:
+		scheme := "ws"
+		if secure {
+			scheme = "wss"
+		}
+		return fmt.Sprintf("%s://%s/ws", scheme, host)
+	case GRPC:
+		port := "80"
+		if secure {
+			port = "443"
+		}
+		return fmt.Sprintf("%s:%s", host, port)
+	default:
+		return ""
+	}
+}
+
+func getEndpoints(region string, protocol Protocol) (string, string) {
+	config := endpointConfigs[region]
+	return buildEndpoint(config.Host, protocol, false), buildEndpoint(config.Host, protocol, true)
+}
+
+func getPumpEndpoints(region string, protocol Protocol) (string, string) {
+	config := endpointConfigs[region]
+	if config.PumpHost == "" {
+		return "", ""
+	}
+	return buildEndpoint(config.PumpHost, protocol, false), buildEndpoint(config.PumpHost, protocol, true)
+}
+
+func GetEndpointsByService(serviceType ServiceType, protocol Protocol) []string {
+	var endpoints []string
+
+	for name, config := range endpointConfigs {
+		if config.ServiceType == serviceType {
+			region := endpointsByRegion[name]
+			switch protocol {
+			case HTTP:
+				endpoints = append(endpoints, region.HTTP, region.HTTPSecure)
+			case WS:
+				endpoints = append(endpoints, region.WS, region.WSSecure)
+			case GRPC:
+				endpoints = append(endpoints, region.GRPC, region.GRPCSecure)
+			}
+		}
+	}
+
+	return endpoints
+}
+
+func GetPumpEndpoints(protocol Protocol) []string {
+	var endpoints []string
+
+	for name, config := range endpointConfigs {
+		if config.PumpHost != "" {
+			region := endpointsByRegion[name]
+			switch protocol {
+			case HTTP:
+				endpoints = append(endpoints, region.PumpHTTP, region.PumpHTTPSecure)
+			case WS:
+				endpoints = append(endpoints, region.PumpWS, region.PumpWSSecure)
+			case GRPC:
+				endpoints = append(endpoints, region.PumpGRPC, region.PumpGRPCSecure)
+			}
+		}
+	}
+
+	return endpoints
+}
+
+func GetFullServiceGRPCAllEndpoints() []string {
+	return GetEndpointsByService(FullService, GRPC)
 }
 
 func GetFullServiceHTTPAllEndpoints() []string {
-	return []string{
-		MainnetNYHTTP,
-		MainnetNYHTTPSecure,
-		MainnetUKHTTP,
-		MainnetUKHTTPSecure,
-	}
+	return GetEndpointsByService(FullService, HTTP)
 }
 
 func GetFullServiceWSAllEndpoints() []string {
-	return []string{
-		MainnetNYWS,
-		MainnetNYWSSecure,
-		MainnetUKWS,
-		MainnetUKWSSecure,
-	}
+	return GetEndpointsByService(FullService, WS)
 }
 
 func GetSubmitOnlyGRPCAllEndpoints() []string {
-	return []string{
-		MainnetAmsterdamGRPC,
-		MainnetAmsterdamGRPCSecure,
-		MainnetLAGRPC,
-		MainnetLAGRPCSecure,
-		MainnetFrankfurtGRPC,
-		MainnetFrankfurtGRPCSecure,
-		MainnetTokyoGRPC,
-		MainnetTokyoGRPCSecure,
-	}
+	return GetEndpointsByService(SubmitOnly, GRPC)
 }
 
 func GetSubmitOnlyHTTPAllEndpoints() []string {
-	return []string{
-		MainnetAmsterdamHTTP,
-		MainnetAmsterdamHTTPSecure,
-		MainnetLAHTTP,
-		MainnetLAHTTPSecure,
-		MainnetFrankfurtHTTP,
-		MainnetFrankfurtHTTPSecure,
-		MainnetTokyoHTTP,
-		MainnetTokyoHTTPSecure,
-	}
+	return GetEndpointsByService(SubmitOnly, HTTP)
 }
 
 func GetSubmitOnlyWSAllEndpoints() []string {
-	return []string{
-		MainnetAmsterdamWS,
-		MainnetAmsterdamWSSecure,
-		MainnetLAWS,
-		MainnetLAWSSecure,
-		MainnetFrankfurtWS,
-		MainnetFrankfurtWSSecure,
-		MainnetTokyoWS,
-		MainnetTokyoWSSecure,
-	}
+	return GetEndpointsByService(SubmitOnly, WS)
 }
 
 func GetPumpGRPCAllEndpoints() []string {
-	return []string{
-		MainnetPumpNYGRPC,
-		MainnetPumpNYGRPCSecure,
-		MainnetPumpUKGRPC,
-		MainnetPumpUKGRPCSecure,
-	}
+	return GetPumpEndpoints(GRPC)
 }
 
 func GetPumpHTTPAllEndpoints() []string {
-	return []string{
-		MainnetPumpNYHTTP,
-		MainnetPumpNYHTTPSecure,
-		MainnetPumpUKHTTP,
-		MainnetPumpUKHTTPSecure,
-	}
+	return GetPumpEndpoints(HTTP)
 }
 
 func GetPumpWSAllEndpoints() []string {
-	return []string{
-		MainnetPumpNYWS,
-		MainnetPumpNYWSSecure,
-		MainnetPumpUKWS,
-		MainnetPumpUKWSSecure,
-	}
-}
-
-// Endpoint string generators
-func httpEndpoint(e Endpoint, secure bool) string {
-	proto := "http"
-	if secure {
-		proto = "https"
-	}
-	return fmt.Sprintf("%s://%s", proto, e)
-}
-
-func wsEndpoint(e Endpoint, secure bool) string {
-	proto := "ws"
-	if secure {
-		proto = "wss"
-	}
-	return fmt.Sprintf("%s://%s/ws", proto, e)
-}
-
-func grpcEndpoint(e Endpoint, secure bool) string {
-	port := "80"
-	if secure {
-		port = "443"
-	}
-	return fmt.Sprintf("%s:%s", e, port)
+	return GetPumpEndpoints(WS)
 }

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
+	"strings"
 
 	package_info "github.com/bloXroute-Labs/solana-trader-client-go"
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
@@ -222,43 +224,62 @@ type GRPCClient struct {
 }
 
 // NewGRPCClientFullService connects to Mainnet Trader API with full service API
-func NewGRPCClientFullService(bloxrouteEndpoint string) (GRPCClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYGRPC && bloxrouteEndpoint != MainnetUKGRPC {
+func NewGRPCClientFullService(endpoint string) (GRPCClientTraderAPI, error) {
+	if !contains(GetFullServiceGRPCAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for a full service trader api")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := strings.HasSuffix(endpoint, "443")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
 
 	return NewGRPCClientWithOpts(opts)
 }
 
 // NewGRPCClientSubmitOnly connects to Mainnet Trader API with full service API
-func NewGRPCClientSubmitOnly(bloxrouteEndpoint string) (GRPCClientTraderAPISubmitOnly, error) {
-	if bloxrouteEndpoint != MainnetAmsterdamGRPC &&
-		bloxrouteEndpoint != MainnetFrankfurtGRPC &&
-		bloxrouteEndpoint != MainnetLAGRPC &&
-		bloxrouteEndpoint != MainnetTokyoGRPC {
+func NewGRPCClientSubmitOnly(endpoint string) (GRPCClientTraderAPISubmitOnly, error) {
+	if !contains(GetSubmitOnlyGRPCAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for submit only trader api")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := strings.HasSuffix(endpoint, "443")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
 
 	return NewGRPCClientWithOpts(opts)
 }
 
 // NewGRPCClientPumpNY connects to Mainnet NY Pump Trader API
-func NewGRPCClientPumpNY() (GRPCClientTraderAPI, error) {
-	opts := DefaultRPCOpts(MainnetPumpNYGRPC)
-	opts.UseTLS = true
+func NewGRPCClientPumpNY(endpoint string) (GRPCClientTraderAPI, error) {
+	if !contains(GetPumpGRPCAllEndpoints(), endpoint) {
+		return nil, fmt.Errorf("not a valid endpoint for trader api pump")
+	}
+
+	isSecure := strings.HasSuffix(endpoint, "443")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
 	return NewGRPCClientWithOpts(opts)
 }
 
 // NewGRPCTestnet connects to Testnet Trader API
 func NewGRPCTestnet() (GRPCClientTraderAPI, error) {
 	opts := DefaultRPCOpts(TestnetGRPC)
-	opts.UseTLS = true
 	return NewGRPCClientWithOpts(opts)
 }
 

--- a/provider/http_interfaces.go
+++ b/provider/http_interfaces.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 	"github.com/bloXroute-Labs/solana-trader-proto/common"
@@ -189,32 +191,57 @@ type HTTPClient struct {
 }
 
 // NewHTTPClientFullService connects to Mainnet Trader pb with full service pb
-func NewHTTPClientFullService(bloxrouteEndpoint string) (HTTPClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYHTTP && bloxrouteEndpoint != MainnetUKHTTP {
+func NewHTTPClientFullService(endpoint string) (HTTPClientTraderAPI, error) {
+	if !contains(GetFullServiceHTTPAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for a full service trader pb")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := strings.HasPrefix(endpoint, "https://")
 
-	httpClient := NewHTTPClientWithOpts(nil, opts)
-	return httpClient, nil
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
+	return NewHTTPClientWithOpts(nil, opts), nil
 }
 
 // NewHTTPClientSubmitOnly connects to Mainnet Trader pb with full service pb
-func NewHTTPClientSubmitOnly(bloxrouteEndpoint string) (HTTPClientTraderAPISubmitOnly, error) {
-	if bloxrouteEndpoint != MainnetAmsterdamHTTP &&
-		bloxrouteEndpoint != MainnetFrankfurtHTTP &&
-		bloxrouteEndpoint != MainnetLAHTTP &&
-		bloxrouteEndpoint != MainnetTokyoHTTP {
+func NewHTTPClientSubmitOnly(endpoint string) (HTTPClientTraderAPISubmitOnly, error) {
+	if !contains(GetSubmitOnlyHTTPAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for submit only trader pb")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := strings.HasPrefix(endpoint, "https://")
 
-	httpClient := NewHTTPClientWithOpts(nil, opts)
-	return httpClient, nil
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
+	return NewHTTPClientWithOpts(nil, opts), nil
+}
+
+// NewHTTPClientPumpNY connects to Mainnet Trader pb
+func NewHTTPClientPumpNY(endpoint string) (HTTPClientTraderAPI, error) {
+	if !contains(GetPumpHTTPAllEndpoints(), endpoint) {
+		return nil, fmt.Errorf("not a valid endpoint for trader api pump")
+	}
+
+	isSecure := strings.HasPrefix(endpoint, "https://")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
+	return NewHTTPClientWithOpts(nil, opts), nil
 }
 
 // NewHTTPClient connects to Mainnet Trader pb
@@ -223,16 +250,9 @@ func NewHTTPClient() HTTPClientTraderAPI {
 	return NewHTTPClientWithOpts(nil, opts)
 }
 
-// NewHTTPClientPumpNY connects to Mainnet Trader pb
-func NewHTTPClientPumpNY() HTTPClientTraderAPI {
-	opts := DefaultRPCOpts(MainnetPumpNYHTTP)
-	return NewHTTPClientWithOpts(nil, opts)
-}
-
 // NewHTTPTestnet connects to Testnet Trader pb
 func NewHTTPTestnet() HTTPClientTraderAPI {
 	opts := DefaultRPCOpts(TestnetHTTP)
-	opts.UseTLS = true
 	return NewHTTPClientWithOpts(nil, opts)
 }
 

--- a/provider/ws_interfaces.go
+++ b/provider/ws_interfaces.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
@@ -187,40 +189,62 @@ type WSClient struct {
 }
 
 // NewWSClientFullService connects to Mainnet Trader API with full service
-func NewWSClientFullService(bloxrouteEndpoint string) (WSClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYWS && bloxrouteEndpoint != MainnetUKWS {
+func NewWSClientFullService(endpoint string) (WSClientTraderAPI, error) {
+	if !contains(GetFullServiceWSAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for a full service trader api")
 	}
 
-	opts := DefaultRPCOpts(MainnetNYWS)
+	isSecure := strings.HasPrefix(endpoint, "wss://")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
 	return NewWSClientWithOpts(opts)
 }
 
 // NewWSClientSubmitOnly connects to Mainnet Trader API with submission only service
-func NewWSClientSubmitOnly(bloxrouteEndpoint string) (WSClientTraderAPISubmitOnly, error) {
-	if bloxrouteEndpoint != MainnetAmsterdamWS &&
-		bloxrouteEndpoint != MainnetFrankfurtWS &&
-		bloxrouteEndpoint != MainnetLAWS &&
-		bloxrouteEndpoint != MainnetTokyoWS {
+func NewWSClientSubmitOnly(endpoint string) (WSClientTraderAPISubmitOnly, error) {
+	if !contains(GetSubmitOnlyWSAllEndpoints(), endpoint) {
 		return nil, fmt.Errorf("not a valid endpoint for submit only trader api")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := strings.HasPrefix(endpoint, "wss://")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
 
 	return NewWSClientWithOpts(opts)
 }
 
 // NewWSClientPumpNY connects to Mainnet NY Pump Trader API
-func NewWSClientPumpNY() (WSClientTraderAPI, error) {
-	opts := DefaultRPCOpts(MainnetPumpNYWS)
+func NewWSClientPumpNY(endpoint string) (WSClientTraderAPI, error) {
+	if !contains(GetPumpWSAllEndpoints(), endpoint) {
+		return nil, fmt.Errorf("not a valid endpoint for trader api pump")
+	}
+
+	isSecure := strings.HasPrefix(endpoint, "wss://")
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(endpoint)
+	opts.UseTLS = isSecure
+
 	return NewWSClientWithOpts(opts)
 }
 
 // NewWSClientTestnet connects to Testnet Trader API
 func NewWSClientTestnet() (WSClientTraderAPI, error) {
 	opts := DefaultRPCOpts(TestnetWS)
-	opts.UseTLS = true
 	return NewWSClientWithOpts(opts)
 }
 


### PR DESCRIPTION
## Changes

- Moved endpoint definitions to dedicated `endpoints.go` file with structured configuration
- Updated client constructors to require explicit endpoint parameters instead of hardcoded values
- Added performance warnings for secure endpoints
- Updated all examples

New constructors follow the format below

```go
func NewClient(endpoint string) (Client, error) {
	if !contains(ClientAllEndpoints(), endpoint) {
		return nil, fmt.Errorf("not a valid endpoint")
	}

	isSecure := strings.HasSuffix(endpoint, secureMarker)

	if isSecure {
		log.Println(WarningTLSSlowDown)
	}

	opts := DefaultRPCOpts(endpoint)
	opts.UseTLS = isSecure

	return NewClientWithOpts(opts)
}
```