### PR TITLE
warn on TLS and do not default

### DIFF
--- a/connections/ws.go
+++ b/connections/ws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -79,7 +80,13 @@ func NewWS(endpoint string, authHeader string, disablePingLoop bool) (*WS, error
 }
 
 func connect(endpoint string, auth string) (*websocket.Conn, error) {
-	dialer := websocket.Dialer{HandshakeTimeout: handshakeTimeout}
+	dialer := websocket.Dialer{
+		HandshakeTimeout: handshakeTimeout,
+		NetDialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 15 * time.Second,
+		}).DialContext,
+	}
 	header := http.Header{}
 	header.Set("Authorization", auth)
 	header.Set("x-sdk", package_info.Name)

--- a/connections/ws.go
+++ b/connections/ws.go
@@ -83,7 +83,7 @@ func connect(endpoint string, auth string) (*websocket.Conn, error) {
 	dialer := websocket.Dialer{
 		HandshakeTimeout: handshakeTimeout,
 		NetDialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   5 * time.Second,
 			KeepAlive: 15 * time.Second,
 		}).DialContext,
 	}

--- a/examples/grpcclient/main.go
+++ b/examples/grpcclient/main.go
@@ -866,7 +866,7 @@ func callGetPumpFunQuotes(g provider.GRPCClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmQuotes(_ provider.GRPCClientTraderAPI) bool {
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1897,7 +1897,7 @@ func callPostPumpFunSwapWrap(g provider.GRPCClientTraderAPI) bool {
 
 func callPostPumpFunSwap(ownerAddr string) bool {
 	log.Info("starting PostPumpFunSwap test")
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -1933,7 +1933,7 @@ func callPostPumpFunSwap(ownerAddr string) bool {
 
 func callPostPumpFunAmmSwap(_ provider.GRPCClientTraderAPI) bool {
 	log.Info("starting PostPumpFunAmmSwap test")
-	g, err := provider.NewGRPCClientPumpNY()
+	g, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}
@@ -2281,7 +2281,7 @@ func callJupiterRouteSwap(g provider.GRPCClientTraderAPI, ownerAddr string) bool
 }
 
 func callGetpumpFunNewTokenGRPCStreamWrap(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2317,7 +2317,7 @@ func callGetPumpFunNewTokensGRPCStream(g provider.GRPCClientTraderAPI) (string, 
 }
 
 func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump provider: %v", err)
 		return true
@@ -2346,7 +2346,7 @@ func callGetPumpFunNewAmmPoolGRPCStream(g provider.GRPCClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmSwapGRPCStream(g provider.GRPCClientTraderAPI) bool {
-	gg, err := provider.NewGRPCClientPumpNY()
+	gg, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		log.Errorf("failed to create pump provider: %v", err)
 		return true

--- a/examples/helpers.go
+++ b/examples/helpers.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetPumpFunNewTokenHelper() (*pb.GetPumpFunNewTokensStreamResponse, error) {
-	grpcClient, err := provider.NewGRPCClientPumpNY()
+	grpcClient, err := provider.NewGRPCClientPumpNY(provider.MainnetPumpNYGRPC)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/wsclient/main.go
+++ b/examples/wsclient/main.go
@@ -908,7 +908,7 @@ func callGetPumpFunQuotes(w provider.WSClientTraderAPI) bool {
 }
 
 func callGetPumpFunAmmQuotes(_ provider.WSClientTraderAPI) bool {
-	w, err := provider.NewWSClientPumpNY()
+	w, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		panic(err)
 	}
@@ -1889,7 +1889,7 @@ func callPostPumpFunSwap(w provider.WSClientTraderAPI, ownerAddr string) bool {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		panic(err)
 	}
@@ -1922,7 +1922,7 @@ func callPostPumpFunSwap(w provider.WSClientTraderAPI, ownerAddr string) bool {
 
 func callPostPumpFunAmmSwap(_ provider.WSClientTraderAPI) bool {
 	log.Info("starting PostPumpFunAmmSwap test")
-	w, err := provider.NewWSClientPumpNY()
+	w, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		panic(err)
 	}
@@ -2311,7 +2311,7 @@ func callGetTickersWSStream(w provider.WSClientTraderAPI) bool {
 }
 
 func callGetPumpFunNewTokensWSStreamWrap(_ provider.WSClientTraderAPI) bool {
-	ww, err := provider.NewWSClientPumpNY()
+	ww, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		panic(err)
 	}
@@ -2351,7 +2351,7 @@ func callGetPumpFunNewTokensWSStream(w provider.WSClientTraderAPI) (string, bool
 
 func callGetPumpFunAmmSwapWSStream(_ provider.WSClientTraderAPI) bool {
 	log.Info("starting GetPumpFunAMMSwap stream")
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		log.Errorf("failed to create pump fun provider: %v", err)
 		return true
@@ -2382,7 +2382,7 @@ func callGetPumpFunAmmSwapWSStream(_ provider.WSClientTraderAPI) bool {
 func callGetPumpFunNewAmmPoolWSStream(w provider.WSClientTraderAPI) bool {
 	log.Info("starting GetPumpFunNewAmmPool stream")
 
-	wp, err := provider.NewWSClientPumpNY()
+	wp, err := provider.NewWSClientPumpNY(provider.MainnetPumpNYWS)
 	if err != nil {
 		log.Errorf("failed to create pump fun provider: %v", err)
 		return true

--- a/provider/common.go
+++ b/provider/common.go
@@ -14,67 +14,140 @@ import (
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 )
 
-const (
-	mainnetNY     = "ny.solana.dex.blxrbdn.com"
-	mainnetPumpNY = "pump-ny.solana.dex.blxrbdn.com"
-	mainnetUK     = "uk.solana.dex.blxrbdn.com"
-	// see https://docs.bloxroute.com/solana/trader-api/introduction/regions for all regions of traderAPI. There are
-	// some regions below that are only available for transaction submission related endpoints, not full API service.
-	mainnetFrankfurt = "germany.solana.dex.blxrbdn.com"
-	mainnetLA        = "la.solana.dex.blxrbdn.com"
-	mainnetAmsterdam = "amsterdam.solana.dex.blxrbdn.com"
-	mainnetTokyo     = "tokyo.solana.dex.blxrbdn.com"
-	testnet          = "solana.dex.bxrtest.com"
-	devnet           = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
-)
+const WarningTLSSlowDown = "Performance Notice: Secure (TLS) endpoints may introduce latency due to handshake overhead. For optimal trading speed, consider using non-secure endpoints when appropriate."
+
+type Region string
 
 // for information about submit only regions, see documentation: https://docs.bloxroute.com/solana/trader-api/introduction/regions
+const (
+	mainnetNY        Region = "ny.solana.dex.blxrbdn.com"
+	mainnetPumpNY    Region = "pump-ny.solana.dex.blxrbdn.com"
+	mainnetUK        Region = "uk.solana.dex.blxrbdn.com"
+	mainnetPumpUK    Region = "pump-uk.solana.dex.blxrbdn.com"
+	mainnetFrankfurt Region = "germany.solana.dex.blxrbdn.com"
+	mainnetLA        Region = "la.solana.dex.blxrbdn.com"
+	mainnetAmsterdam Region = "amsterdam.solana.dex.blxrbdn.com"
+	mainnetTokyo     Region = "tokyo.solana.dex.blxrbdn.com"
+	testnet          Region = "solana.dex.bxrtest.com"
+	devnet           Region = "solana-trader-api-nlb-6b0f765f2fc759e1.elb.us-east-1.amazonaws.com"
+)
 
 var (
-	MainnetNYHTTP     = httpEndpoint(mainnetNY, true)
-	MainnetPumpNYHTTP = httpEndpoint(mainnetPumpNY, true)
-	MainnetUKHTTP     = httpEndpoint(mainnetUK, true)
 
-	// submit only http
-	MainnetFrankfurtHTTP = httpEndpoint(mainnetFrankfurt, true)
-	MainnetLAHTTP        = httpEndpoint(mainnetLA, true)
-	MainnetAmsterdamHTTP = httpEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoHTTP     = httpEndpoint(mainnetTokyo, true)
+	// FULL SERVICE
 
-	MainnetNYWS     = wsEndpoint(mainnetNY, true)
-	MainnetPumpNYWS = wsEndpoint(mainnetPumpNY, true)
-	MainnetUKWS     = wsEndpoint(mainnetUK, true)
+	// http
+	MainnetNYHTTP     = httpEndpoint(mainnetNY, false)
+	MainnetPumpNYHTTP = httpEndpoint(mainnetPumpNY, false)
+	MainnetUKHTTP     = httpEndpoint(mainnetUK, false)
+	MainnetPumpUKHTTP = httpEndpoint(mainnetPumpUK, false)
 
-	// submit only ws
-	MainnetFrankfurtWS = wsEndpoint(mainnetFrankfurt, true)
-	MainnetLAWS        = wsEndpoint(mainnetLA, true)
-	MainnetAmsterdamWS = wsEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoWS     = wsEndpoint(mainnetTokyo, true)
+	// grpc
+	MainnetNYGRPC     = grpcEndpoint(mainnetNY, false)
+	MainnetPumpNYGRPC = grpcEndpoint(mainnetPumpNY, false)
+	MainnetUKGRPC     = grpcEndpoint(mainnetUK, false)
+	MainnetPumpUKGRPC = grpcEndpoint(mainnetPumpUK, false)
 
-	MainnetNYGRPC     = grpcEndpoint(mainnetNY, true)
-	MainnetPumpNYGRPC = grpcEndpoint(mainnetPumpNY, true)
-	MainnetUKGRPC     = grpcEndpoint(mainnetUK, true)
+	// ws
+	MainnetNYWS     = wsEndpoint(mainnetNY, false)
+	MainnetPumpNYWS = wsEndpoint(mainnetPumpNY, false)
+	MainnetUKWS     = wsEndpoint(mainnetUK, false)
+	MainnetPumpUKWS = wsEndpoint(mainnetPumpUK, false)
 
-	// submit only grpc
-	MainnetFrankfurtGRPC = grpcEndpoint(mainnetFrankfurt, true)
-	MainnetLAGRPC        = grpcEndpoint(mainnetLA, true)
-	MainnetAmsterdamGRPC = grpcEndpoint(mainnetAmsterdam, true)
-	MainnetTokyoGRPC     = grpcEndpoint(mainnetTokyo, true)
+	// SUBMIT ONLY
 
-	TestnetHTTP = httpEndpoint(testnet, true)
-	TestnetWS   = wsEndpoint(testnet, true)
-	TestnetGRPC = grpcEndpoint(testnet, true)
+	// http
+	MainnetFrankfurtHTTP = httpEndpoint(mainnetFrankfurt, false)
+	MainnetLAHTTP        = httpEndpoint(mainnetLA, false)
+	MainnetAmsterdamHTTP = httpEndpoint(mainnetAmsterdam, false)
+	MainnetTokyoHTTP     = httpEndpoint(mainnetTokyo, false)
 
+	// grpc
+	MainnetFrankfurtGRPC = grpcEndpoint(mainnetFrankfurt, false)
+	MainnetLAGRPC        = grpcEndpoint(mainnetLA, false)
+	MainnetAmsterdamGRPC = grpcEndpoint(mainnetAmsterdam, false)
+	MainnetTokyoGRPC     = grpcEndpoint(mainnetTokyo, false)
+
+	// ws
+	MainnetFrankfurtWS = wsEndpoint(mainnetFrankfurt, false)
+	MainnetLAWS        = wsEndpoint(mainnetLA, false)
+	MainnetAmsterdamWS = wsEndpoint(mainnetAmsterdam, false)
+	MainnetTokyoWS     = wsEndpoint(mainnetTokyo, false)
+
+	// TESTING
+
+	// testnet
+	TestnetHTTP = httpEndpoint(testnet, false)
+	TestnetWS   = wsEndpoint(testnet, false)
+	TestnetGRPC = grpcEndpoint(testnet, false)
+
+	// devnet
 	DevnetHTTP = httpEndpoint(devnet, false)
 	DevnetWS   = wsEndpoint(devnet, false)
 	DevnetGRPC = grpcEndpoint(devnet, false)
 
+	// local
 	LocalHTTP = "http://localhost:9000"
 	LocalWS   = "ws://localhost:9000/ws"
 	LocalGRPC = "localhost:9000"
 )
 
-func httpEndpoint(baseUrl string, secure bool) string {
+var (
+
+	// FULL SERVICE
+
+	// http
+	MainnetNYHTTPSecure     = httpEndpoint(mainnetNY, true)
+	MainnetPumpNYHTTPSecure = httpEndpoint(mainnetPumpNY, true)
+	MainnetUKHTTPSecure     = httpEndpoint(mainnetUK, true)
+	MainnetPumpUKHTTPSecure = httpEndpoint(mainnetPumpUK, true)
+
+	// grpc
+	MainnetNYGRPCSecure     = grpcEndpoint(mainnetNY, true)
+	MainnetPumpNYGRPCSecure = grpcEndpoint(mainnetPumpNY, true)
+	MainnetUKGRPCSecure     = grpcEndpoint(mainnetUK, true)
+	MainnetPumpUKGRPCSecure = grpcEndpoint(mainnetPumpUK, true)
+
+	// ws
+	MainnetNYWSSecure     = wsEndpoint(mainnetNY, true)
+	MainnetPumpNYWSSecure = wsEndpoint(mainnetPumpNY, true)
+	MainnetUKWSSecure     = wsEndpoint(mainnetUK, true)
+	MainnetPumpUKWSSecure = wsEndpoint(mainnetPumpUK, true)
+
+	// SUBMIT ONLY
+
+	// http
+	MainnetFrankfurtHTTPSecure = httpEndpoint(mainnetFrankfurt, true)
+	MainnetLAHTTPSecure        = httpEndpoint(mainnetLA, true)
+	MainnetAmsterdamHTTPSecure = httpEndpoint(mainnetAmsterdam, true)
+	MainnetTokyoHTTPSecure     = httpEndpoint(mainnetTokyo, true)
+
+	// grpc
+	MainnetFrankfurtGRPCSecure = grpcEndpoint(mainnetFrankfurt, true)
+	MainnetLAGRPCSecure        = grpcEndpoint(mainnetLA, true)
+	MainnetAmsterdamGRPCSecure = grpcEndpoint(mainnetAmsterdam, true)
+	MainnetTokyoGRPCSecure     = grpcEndpoint(mainnetTokyo, true)
+
+	// ws
+	MainnetFrankfurtWSSecure = wsEndpoint(mainnetFrankfurt, true)
+	MainnetLAWSSecure        = wsEndpoint(mainnetLA, true)
+	MainnetAmsterdamWSSecure = wsEndpoint(mainnetAmsterdam, true)
+	MainnetTokyoWSSecure     = wsEndpoint(mainnetTokyo, true)
+
+	// TESTING
+
+	// testnet
+	TestnetHTTPSecure = httpEndpoint(testnet, true)
+	TestnetWSSecure   = wsEndpoint(testnet, true)
+	TestnetGRPCSecure = grpcEndpoint(testnet, true)
+
+	// devnet
+	DevnetHTTPSecure = httpEndpoint(devnet, true)
+	DevnetWSSecure   = wsEndpoint(devnet, true)
+	DevnetGRPCSecure = grpcEndpoint(devnet, true)
+)
+
+func httpEndpoint(baseUrl Region, secure bool) string {
 	prefix := "http"
 	if secure {
 		prefix = "https"
@@ -82,7 +155,7 @@ func httpEndpoint(baseUrl string, secure bool) string {
 	return fmt.Sprintf("%v://%v", prefix, baseUrl)
 }
 
-func wsEndpoint(baseUrl string, secure bool) string {
+func wsEndpoint(baseUrl Region, secure bool) string {
 	prefix := "ws"
 	if secure {
 		prefix = "wss"
@@ -90,7 +163,7 @@ func wsEndpoint(baseUrl string, secure bool) string {
 	return fmt.Sprintf("%v://%v/ws", prefix, baseUrl)
 }
 
-func grpcEndpoint(baseUrl string, secure bool) string {
+func grpcEndpoint(baseUrl Region, secure bool) string {
 	port := "80"
 	if secure {
 		port = "443"
@@ -197,4 +270,14 @@ func createBatchRequestEntry(opts SubmitOpts, txBase64 string, privateKey solana
 	}
 
 	return &oneRequest, nil
+}
+
+func isSecureGRPC(bloxrouteEndpoint string) bool {
+	return strings.HasSuffix(bloxrouteEndpoint, "443")
+}
+func isSecureHTTP(bloxrouteEndpoint string) bool {
+	return strings.HasPrefix(bloxrouteEndpoint, "https://")
+}
+func isSecureWS(bloxrouteEndpoint string) bool {
+	return strings.HasPrefix(bloxrouteEndpoint, "ws://")
 }

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 
 	package_info "github.com/bloXroute-Labs/solana-trader-client-go"
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
@@ -223,12 +224,21 @@ type GRPCClient struct {
 
 // NewGRPCClientFullService connects to Mainnet Trader API with full service API
 func NewGRPCClientFullService(bloxrouteEndpoint string) (GRPCClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYGRPC && bloxrouteEndpoint != MainnetUKGRPC {
+	if bloxrouteEndpoint != MainnetNYGRPC &&
+		bloxrouteEndpoint != MainnetUKGRPC &&
+		bloxrouteEndpoint != MainnetNYGRPCSecure &&
+		bloxrouteEndpoint != MainnetUKGRPCSecure {
 		return nil, fmt.Errorf("not a valid endpoint for a full service trader api")
 	}
 
+	isSecure := isSecureGRPC(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
 	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	opts.UseTLS = isSecure
 
 	return NewGRPCClientWithOpts(opts)
 }
@@ -238,20 +248,44 @@ func NewGRPCClientSubmitOnly(bloxrouteEndpoint string) (GRPCClientTraderAPISubmi
 	if bloxrouteEndpoint != MainnetAmsterdamGRPC &&
 		bloxrouteEndpoint != MainnetFrankfurtGRPC &&
 		bloxrouteEndpoint != MainnetLAGRPC &&
-		bloxrouteEndpoint != MainnetTokyoGRPC {
+		bloxrouteEndpoint != MainnetTokyoGRPC &&
+		bloxrouteEndpoint != MainnetAmsterdamGRPCSecure &&
+		bloxrouteEndpoint != MainnetFrankfurtGRPCSecure &&
+		bloxrouteEndpoint != MainnetLAGRPCSecure &&
+		bloxrouteEndpoint != MainnetTokyoGRPCSecure {
 		return nil, fmt.Errorf("not a valid endpoint for submit only trader api")
 	}
 
+	isSecure := isSecureGRPC(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
 	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	opts.UseTLS = isSecure
 
 	return NewGRPCClientWithOpts(opts)
 }
 
 // NewGRPCClientPumpNY connects to Mainnet NY Pump Trader API
-func NewGRPCClientPumpNY() (GRPCClientTraderAPI, error) {
-	opts := DefaultRPCOpts(MainnetPumpNYGRPC)
-	opts.UseTLS = true
+func NewGRPCClientPumpNY(bloxrouteEndpoint string) (GRPCClientTraderAPI, error) {
+	if bloxrouteEndpoint != MainnetPumpNYGRPC &&
+		bloxrouteEndpoint != MainnetPumpUKGRPC &&
+		bloxrouteEndpoint != MainnetPumpNYGRPCSecure &&
+		bloxrouteEndpoint != MainnetPumpUKGRPCSecure {
+		return nil, fmt.Errorf("not a valid endpoint for a trader api pump")
+	}
+
+	isSecure := isSecureGRPC(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(bloxrouteEndpoint)
+	opts.UseTLS = isSecure
+
 	return NewGRPCClientWithOpts(opts)
 }
 

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"time"
 
 	package_info "github.com/bloXroute-Labs/solana-trader-client-go"
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
 type GRPCClientTraderAPISubmitOnly interface {
@@ -292,7 +294,6 @@ func NewGRPCClientPumpNY(bloxrouteEndpoint string) (GRPCClientTraderAPI, error) 
 // NewGRPCTestnet connects to Testnet Trader API
 func NewGRPCTestnet() (GRPCClientTraderAPI, error) {
 	opts := DefaultRPCOpts(TestnetGRPC)
-	opts.UseTLS = true
 	return NewGRPCClientWithOpts(opts)
 }
 
@@ -343,6 +344,14 @@ func NewGRPCClientWithOpts(opts RPCOpts, dialOpts ...grpc.DialOption) (*GRPCClie
 	}
 	grpcOpts = append(grpcOpts, grpc.WithDefaultCallOptions(&grpc.MaxRecvMsgSizeCallOption{MaxRecvMsgSize: 1024 * 1024 * 16}))
 	grpcOpts = append(grpcOpts, dialOpts...)
+
+	keepaliveParams := grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                15 * time.Second,
+		Timeout:             30 * time.Second,
+		PermitWithoutStream: true,
+	})
+	grpcOpts = append(grpcOpts, keepaliveParams)
+
 	conn, err = grpc.NewClient(opts.Endpoint, grpcOpts...)
 	if err != nil {
 		return nil, err

--- a/provider/grpc_interfaces.go
+++ b/provider/grpc_interfaces.go
@@ -347,7 +347,7 @@ func NewGRPCClientWithOpts(opts RPCOpts, dialOpts ...grpc.DialOption) (*GRPCClie
 
 	keepaliveParams := grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		Time:                15 * time.Second,
-		Timeout:             30 * time.Second,
+		Timeout:             5 * time.Second,
 		PermitWithoutStream: true,
 	})
 	grpcOpts = append(grpcOpts, keepaliveParams)

--- a/provider/http_interfaces.go
+++ b/provider/http_interfaces.go
@@ -276,7 +276,7 @@ func NewHTTPClientWithOpts(client *http.Client, opts RPCOpts) *HTTPClient {
 			MaxIdleConns:        200,
 			MaxIdleConnsPerHost: 20,
 			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
+				Timeout:   5 * time.Second,
 				KeepAlive: 15 * time.Second,
 			}).DialContext,
 		}

--- a/provider/http_interfaces.go
+++ b/provider/http_interfaces.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"time"
 
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
 	"github.com/bloXroute-Labs/solana-trader-proto/common"
@@ -250,7 +252,6 @@ func NewHTTPClientPumpNY() HTTPClientTraderAPI {
 // NewHTTPTestnet connects to Testnet Trader pb
 func NewHTTPTestnet() HTTPClientTraderAPI {
 	opts := DefaultRPCOpts(TestnetHTTP)
-	opts.UseTLS = true
 	return NewHTTPClientWithOpts(nil, opts)
 }
 
@@ -269,7 +270,19 @@ func NewHTTPLocal() HTTPClientTraderAPI {
 // NewHTTPClientWithOpts connects to custom Trader pb (set client to nil to use default client)
 func NewHTTPClientWithOpts(client *http.Client, opts RPCOpts) *HTTPClient {
 	if client == nil {
-		client = &http.Client{}
+		transport := &http.Transport{
+			DisableKeepAlives:   false,
+			IdleConnTimeout:     0,
+			MaxIdleConns:        200,
+			MaxIdleConnsPerHost: 20,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 15 * time.Second,
+			}).DialContext,
+		}
+		client = &http.Client{
+			Transport: transport,
+		}
 	}
 
 	return &HTTPClient{

--- a/provider/http_interfaces.go
+++ b/provider/http_interfaces.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
@@ -190,15 +191,23 @@ type HTTPClient struct {
 
 // NewHTTPClientFullService connects to Mainnet Trader pb with full service pb
 func NewHTTPClientFullService(bloxrouteEndpoint string) (HTTPClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYHTTP && bloxrouteEndpoint != MainnetUKHTTP {
-		return nil, fmt.Errorf("not a valid endpoint for a full service trader pb")
+	if bloxrouteEndpoint != MainnetNYHTTP &&
+		bloxrouteEndpoint != MainnetUKHTTP &&
+		bloxrouteEndpoint != MainnetNYHTTPSecure &&
+		bloxrouteEndpoint != MainnetUKHTTPSecure {
+		return nil, fmt.Errorf("not a valid endpoint for a full service trader api")
+	}
+
+	isSecure := isSecureHTTP(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
 	}
 
 	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	opts.UseTLS = isSecure
 
-	httpClient := NewHTTPClientWithOpts(nil, opts)
-	return httpClient, nil
+	return NewHTTPClientWithOpts(nil, opts), nil
 }
 
 // NewHTTPClientSubmitOnly connects to Mainnet Trader pb with full service pb
@@ -206,15 +215,24 @@ func NewHTTPClientSubmitOnly(bloxrouteEndpoint string) (HTTPClientTraderAPISubmi
 	if bloxrouteEndpoint != MainnetAmsterdamHTTP &&
 		bloxrouteEndpoint != MainnetFrankfurtHTTP &&
 		bloxrouteEndpoint != MainnetLAHTTP &&
-		bloxrouteEndpoint != MainnetTokyoHTTP {
-		return nil, fmt.Errorf("not a valid endpoint for submit only trader pb")
+		bloxrouteEndpoint != MainnetTokyoHTTP &&
+		bloxrouteEndpoint != MainnetAmsterdamHTTPSecure &&
+		bloxrouteEndpoint != MainnetFrankfurtHTTPSecure &&
+		bloxrouteEndpoint != MainnetLAHTTPSecure &&
+		bloxrouteEndpoint != MainnetTokyoHTTPSecure {
+		return nil, fmt.Errorf("not a valid endpoint for submit only trader api")
+	}
+
+	isSecure := isSecureHTTP(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
 	}
 
 	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	opts.UseTLS = isSecure
 
-	httpClient := NewHTTPClientWithOpts(nil, opts)
-	return httpClient, nil
+	return NewHTTPClientWithOpts(nil, opts), nil
 }
 
 // NewHTTPClient connects to Mainnet Trader pb

--- a/provider/ws_interfaces.go
+++ b/provider/ws_interfaces.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/bloXroute-Labs/solana-trader-client-go/connections"
 	pb "github.com/bloXroute-Labs/solana-trader-proto/api"
@@ -188,11 +189,22 @@ type WSClient struct {
 
 // NewWSClientFullService connects to Mainnet Trader API with full service
 func NewWSClientFullService(bloxrouteEndpoint string) (WSClientTraderAPI, error) {
-	if bloxrouteEndpoint != MainnetNYWS && bloxrouteEndpoint != MainnetUKWS {
+	if bloxrouteEndpoint != MainnetNYWS &&
+		bloxrouteEndpoint != MainnetUKWS &&
+		bloxrouteEndpoint != MainnetNYWSSecure &&
+		bloxrouteEndpoint != MainnetUKWSSecure {
 		return nil, fmt.Errorf("not a valid endpoint for a full service trader api")
 	}
 
+	isSecure := isSecureWS(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
 	opts := DefaultRPCOpts(MainnetNYWS)
+	opts.UseTLS = isSecure
+
 	return NewWSClientWithOpts(opts)
 }
 
@@ -201,19 +213,44 @@ func NewWSClientSubmitOnly(bloxrouteEndpoint string) (WSClientTraderAPISubmitOnl
 	if bloxrouteEndpoint != MainnetAmsterdamWS &&
 		bloxrouteEndpoint != MainnetFrankfurtWS &&
 		bloxrouteEndpoint != MainnetLAWS &&
-		bloxrouteEndpoint != MainnetTokyoWS {
+		bloxrouteEndpoint != MainnetTokyoWS &&
+		bloxrouteEndpoint != MainnetAmsterdamWSSecure &&
+		bloxrouteEndpoint != MainnetFrankfurtWSSecure &&
+		bloxrouteEndpoint != MainnetLAWSSecure &&
+		bloxrouteEndpoint != MainnetTokyoWSSecure {
 		return nil, fmt.Errorf("not a valid endpoint for submit only trader api")
 	}
 
-	opts := DefaultRPCOpts(bloxrouteEndpoint)
-	opts.UseTLS = true
+	isSecure := isSecureWS(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(MainnetNYWS)
+	opts.UseTLS = isSecure
 
 	return NewWSClientWithOpts(opts)
 }
 
 // NewWSClientPumpNY connects to Mainnet NY Pump Trader API
-func NewWSClientPumpNY() (WSClientTraderAPI, error) {
-	opts := DefaultRPCOpts(MainnetPumpNYWS)
+func NewWSClientPumpNY(bloxrouteEndpoint string) (WSClientTraderAPI, error) {
+	if bloxrouteEndpoint != MainnetPumpNYWS &&
+		bloxrouteEndpoint != MainnetPumpUKWS &&
+		bloxrouteEndpoint != MainnetPumpNYWSSecure &&
+		bloxrouteEndpoint != MainnetPumpUKWSSecure {
+		return nil, fmt.Errorf("not a valid endpoint for a trader api pump")
+	}
+
+	isSecure := isSecureWS(bloxrouteEndpoint)
+
+	if isSecure {
+		log.Println(WarningTLSSlowDown)
+	}
+
+	opts := DefaultRPCOpts(MainnetNYWS)
+	opts.UseTLS = isSecure
+
 	return NewWSClientWithOpts(opts)
 }
 


### PR DESCRIPTION
### Changes Overview

#### New Endpoint Naming Convention

* Two distinct endpoint names are now available for each DNS location:

  * For example: `MainnetNYHTTP` (non-TLS) and `MainnetNYHTTPSecure` (TLS).
* Previously, endpoints defaulted to TLS. This behavior has been corrected.

#### Provider Interface Updates

* Functions used to create providers have been updated to:

  * Check whether the endpoint uses TLS and issue a warning about potential performance implications.
  * Eliminate the default use of TLS unless explicitly specified by the client.

#### Connection Management

**gRPC:**

* Configured client keepalive parameters:

  * Keepalive ping interval: 15 seconds.
  * Keepalive timeout: 5 seconds.
  * `PermitWithoutStream` set to `true`, allowing keepalive pings even when there are no active streams.
* Note: `MaxConnectionIdle` is not applicable on the client side, but keepalives can achieve a similar effect.

**HTTP:**

* Set `IdleConnTimeout` to `0` to prevent idle connection closure.
* Enabled TCP keepalive using `net.Dialer` with:

  * Keepalive interval: 15 seconds.
  * Timeout: 5 seconds.
* Increased idle connection limits:

  * Max idle connections: 200.
  * Max idle connections per host: 20.

**WebSocket:**

* Updated the WebSocket dialer to:

  * Enable TCP keepalive with a 15-second interval.
  * Set a 5-second ping timeout.

#### Example Usage Updates

* Clients are no longer required to use TLS or the NY region by default when creating pump providers.
* Instead of calling fixed-region constructors like `New<ConnectionType>ClientPumpNY()`, clients should now use:

  * `New<ConnectionType>ClientPump(endpoint)` with configurable region and TLS options.
